### PR TITLE
[feat] 이메일 인증 로직 구현

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -59,4 +59,10 @@ export const status = {
     code: "USER000",
     message: "사용자 인증에 실패했습니다.",
   },
+  WRONG_CODE: {
+    status: StatusCodes.BAD_REQUEST,
+    isSuccess: false,
+    code: "USER001",
+    message: "잘못된 인증코드 입니다.",
+  },
 };

--- a/domains/user/user.controller.js
+++ b/domains/user/user.controller.js
@@ -1,5 +1,6 @@
 import { response } from "../../config/response.js";
 import { status } from "../../config/response.status.js";
+import { sendCodeEmail } from "../../utils/email.js";
 
 import { loginUser, signupUser } from "./user.service.js";
 
@@ -23,6 +24,19 @@ export const userLogin = async (req, res, next) => {
     const { email, password } = req.body;
     const result = await loginUser(email, password);
     res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const userCreateCode = async (req, res, next) => {
+  try {
+    console.log("이메일 코드 생성 요청");
+    console.log("body: ", req.body);
+
+    const { email } = req.body;
+    const { to, code } = sendCodeEmail(email);
+    res.status(200).json(response(status.SUCCESS, "이메일 코드 생성 완료"));
   } catch (error) {
     next(error);
   }

--- a/domains/user/user.controller.js
+++ b/domains/user/user.controller.js
@@ -29,6 +29,8 @@ export const userLogin = async (req, res, next) => {
   }
 };
 
+let verificationCode = {};
+
 export const userCreateCode = async (req, res, next) => {
   try {
     console.log("이메일 코드 생성 요청");
@@ -36,6 +38,7 @@ export const userCreateCode = async (req, res, next) => {
 
     const { email } = req.body;
     const { to, code } = sendCodeEmail(email);
+    verificationCode[to] = code;
     res.status(200).json(response(status.SUCCESS, "이메일 코드 생성 완료"));
   } catch (error) {
     next(error);

--- a/domains/user/user.controller.js
+++ b/domains/user/user.controller.js
@@ -29,7 +29,7 @@ export const userLogin = async (req, res, next) => {
   }
 };
 
-let verificationCode = {};
+const verificationCode = {};
 
 export const userCreateCode = async (req, res, next) => {
   try {
@@ -39,7 +39,27 @@ export const userCreateCode = async (req, res, next) => {
     const { email } = req.body;
     const { to, code } = sendCodeEmail(email);
     verificationCode[to] = code;
-    res.status(200).json(response(status.SUCCESS, "이메일 코드 생성 완료"));
+
+    res.status(200).json(response(status.SUCCESS, "이메일을 확인해주세요."));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const userConfirmCode = async (req, res, next) => {
+  try {
+    console.log("코드 인증 요청");
+    console.log("body: ", req.body);
+
+    const { email, code } = req.body;
+    const verify = verificationCode[email];
+
+    if (verify === code) {
+      res.status(200).json(response(status.SUCCESS, { verified: true }));
+      delete verificationCode[email];
+    } else {
+      res.status(400).json(response(status.WRONG_CODE, { verified: false }));
+    }
   } catch (error) {
     next(error);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,11 @@
         "express": "^4.19.2",
         "express-async-handler": "^1.2.0",
         "http-status-codes": "^2.3.0",
+        "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "multer-s3": "^2.10.0",
-        "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.10.3",
+        "nodemailer": "^6.9.14",
         "uuid": "^10.0.0",
         "yamljs": "^0.3.0"
       },
@@ -2433,6 +2434,7 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -4343,6 +4345,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.17.tgz",
       "integrity": "sha512-Ww6ZlOiEQfPfXM45v17oabk77Z7mg5bOt7AjDyzy7RjK9OrLrLC8dyZQoAPEOtFX9SaNf1Tdvr5gRJWdTJj7GA==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.14",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.14.tgz",
+      "integrity": "sha512-Dobp/ebDKBvz91sbtRKhcznLThrKxKt97GI2FAlAyy+fk19j73Uz3sBXolVtmcXjaorivqsbbbjDY+Jkt4/bQA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.4",
@@ -7680,6 +7690,7 @@
           "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         }
       }
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -9086,6 +9097,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.17.tgz",
       "integrity": "sha512-Ww6ZlOiEQfPfXM45v17oabk77Z7mg5bOt7AjDyzy7RjK9OrLrLC8dyZQoAPEOtFX9SaNf1Tdvr5gRJWdTJj7GA==",
       "dev": true
+    },
+    "nodemailer": {
+      "version": "6.9.14",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.14.tgz",
+      "integrity": "sha512-Dobp/ebDKBvz91sbtRKhcznLThrKxKt97GI2FAlAyy+fk19j73Uz3sBXolVtmcXjaorivqsbbbjDY+Jkt4/bQA=="
     },
     "nodemon": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "express": "^4.19.2",
     "express-async-handler": "^1.2.0",
     "http-status-codes": "^2.3.0",
+    "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
     "multer-s3": "^2.10.0",
-    "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.10.3",
+    "nodemailer": "^6.9.14",
     "uuid": "^10.0.0",
     "yamljs": "^0.3.0"
   },

--- a/routes/user.route.js
+++ b/routes/user.route.js
@@ -1,10 +1,12 @@
 import express from "express";
 import expressAsyncHandler from "express-async-handler";
 
-import { userLogin, userSignUp } from "../domains/user/user.controller.js";
+import { userCreateCode, userLogin, userSignUp } from "../domains/user/user.controller.js";
 
 export const userRouter = express.Router();
 
 userRouter.post("/signup", expressAsyncHandler(userSignUp));
 
 userRouter.post("/login", expressAsyncHandler(userLogin));
+
+userRouter.post("/create-code", expressAsyncHandler(userCreateCode));

--- a/routes/user.route.js
+++ b/routes/user.route.js
@@ -1,7 +1,12 @@
 import express from "express";
 import expressAsyncHandler from "express-async-handler";
 
-import { userCreateCode, userLogin, userSignUp } from "../domains/user/user.controller.js";
+import {
+  userConfirmCode,
+  userCreateCode,
+  userLogin,
+  userSignUp,
+} from "../domains/user/user.controller.js";
 
 export const userRouter = express.Router();
 
@@ -10,3 +15,5 @@ userRouter.post("/signup", expressAsyncHandler(userSignUp));
 userRouter.post("/login", expressAsyncHandler(userLogin));
 
 userRouter.post("/create-code", expressAsyncHandler(userCreateCode));
+
+userRouter.post("/confirm-code", expressAsyncHandler(userConfirmCode));

--- a/utils/email.js
+++ b/utils/email.js
@@ -1,0 +1,32 @@
+import nodemailer from "nodemailer";
+import dotenv from "dotenv";
+import { v4 as uuidv4 } from "uuid";
+
+dotenv.config();
+
+const { EMAIL_SERVICE: service, EMAIL_USER: user, EMAIL_PASSWORD: pass } = process.env;
+
+export const sendCodeEmail = (to) => {
+  const code = uuidv4().slice(0, 6);
+  const transporter = nodemailer.createTransport({
+    service,
+    auth: {
+      user,
+      pass,
+    },
+  });
+
+  const mailOptions = {
+    from: user,
+    to,
+    subject: "READ.ME 회원가입 인증 코드입니다.",
+    text: `인증 코드: ${code}`,
+  };
+
+  transporter.sendMail(mailOptions, (error, info) => {
+    if (error) {
+      throw new Error(error);
+    }
+  });
+  return { to, code };
+};


### PR DESCRIPTION
# 🚩 관련 이슈

[feat] 이메일 인증 로직 구현 #15 

닫을 이슈 번호: resolved #15 

## 📌 반영 브랜치

feat/#15 -> dev

## 📋 내용

이메일로 인증 코드 보내고, 이를 이용하여 코드 인증하는 로직 구현했습니다.

### 🖼️ 스크린샷 (선택)

#### 이메일로 인증 코드 보내는 작업 성공했을 때
![스크린샷 2024-07-25 오전 1 56 13](https://github.com/user-attachments/assets/b9d28fb9-1f43-4142-b190-1bb76b30bf4c)

#### 이메일로 받은 인증 코드 인증에 성공했을 때
![스크린샷 2024-07-25 오전 1 56 17](https://github.com/user-attachments/assets/c4b88206-62b4-46d8-a89a-c8dbbfb47732)

#### 이메일로 받은 인증 코드 인증에 실패했을 때
![스크린샷 2024-07-25 오전 1 57 35](https://github.com/user-attachments/assets/1869b77c-70f4-4518-8c5b-6c1c2fdf9cc2)

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
