### PR TITLE
[feat] 토큰 구분 로직 구현

### DIFF
--- a/middleware/token.auth.js
+++ b/middleware/token.auth.js
@@ -24,19 +24,19 @@ export const tokenAuth = async (req, res, next) => {
       });
     } else {
       // 카카오 토큰인 경우
-      const response = await getKakaoUser(token);
-      if (response.code === -401) {
+      const userResponse = await getKakaoUser(token);
+      if (userResponse.code === -401) {
         // 카카오 토큰이 만료 혹은 잘못된 경우
         return res.send(response(status.UNAUTHORIZED));
       }
 
-      const user = await findUserByEmail(response.kakao_account.email);
+      const user = await findUserByEmail(userResponse.kakao_account.email);
       if (!user) {
         // DB에 등록되지 않은 사용자일 경우
         return res.send(response(status.BAD_REQUEST));
       }
 
-      req.user = user.id;
+      req.user = { userId: user.id };
     }
 
     next();

--- a/middleware/token.auth.js
+++ b/middleware/token.auth.js
@@ -1,8 +1,10 @@
 import jwt from "jsonwebtoken";
 import { response } from "../config/response.js";
 import { status } from "../config/response.status.js";
+import { checkToken, getKakaoUser } from "../utils/kakao.js";
+import { findUserByEmail } from "../domains/user/user.dao.js";
 
-export const tokenAuth = (req, res, next) => {
+export const tokenAuth = async (req, res, next) => {
   try {
     const header = req.headers["authorization"] || req.headers["Authorization"];
 
@@ -12,15 +14,32 @@ export const tokenAuth = (req, res, next) => {
       return res.send(response(status.EMPTY_TOKEN));
     }
 
-    jwt.verify(token, process.env.JWT_SECRET_KEY, (error, user) => {
-      if (error) {
-        return res.send(response(status.FORBIDDEN));
+    if (!(await checkToken(token))) {
+      jwt.verify(token, process.env.JWT_SECRET_KEY, (error, user) => {
+        if (error) {
+          return res.send(response(status.FORBIDDEN));
+        }
+        // 일반 토큰인 경우
+        req.user = user;
+      });
+    } else {
+      // 카카오 토큰인 경우
+      const response = await getKakaoUser(token);
+      if (response.code === -401) {
+        // 카카오 토큰이 만료 혹은 잘못된 경우
+        return res.send(response(status.UNAUTHORIZED));
       }
 
-      req.user = user;
+      const user = await findUserByEmail(response.kakao_account.email);
+      if (!user) {
+        // DB에 등록되지 않은 사용자일 경우
+        return res.send(response(status.BAD_REQUEST));
+      }
 
-      next();
-    });
+      req.user = user.id;
+    }
+
+    next();
   } catch (error) {
     console.log(error);
   }

--- a/utils/kakao.js
+++ b/utils/kakao.js
@@ -20,7 +20,8 @@ export const getKakaoUser = async (token) => {
   const response = await fetch("https://kapi.kakao.com/v2/user/me", {
     method: "GET",
     headers: {
-      Authorization: `Bearer ${token}`,
+      // Authorization: `Bearer ${token}`,
+      Authorization: `Bearer IrDKo0SmpONQCaWUD-qO-Rary5xo2hNYAAAAAQoqJVEAAAGRDwp1AeiSikwhug`,
       "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
     },
   }).then((res) => res.json());
@@ -36,9 +37,6 @@ export const checkToken = async (token) => {
     },
   }).then((res) => res.json());
 
-  if (response.code === -401) {
-    // refresh token 요청하는 로직 필요
-    return false;
-  }
+  if (response.code === -401) return false;
   return true;
 };

--- a/utils/kakao.js
+++ b/utils/kakao.js
@@ -21,7 +21,7 @@ export const getKakaoUser = async (token) => {
     method: "GET",
     headers: {
       // Authorization: `Bearer ${token}`,
-      Authorization: `Bearer IrDKo0SmpONQCaWUD-qO-Rary5xo2hNYAAAAAQoqJVEAAAGRDwp1AeiSikwhug`,
+      Authorization: `Bearer ${token}`,
       "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
     },
   }).then((res) => res.json());


### PR DESCRIPTION
# 🚩 관련 이슈

> [feat] 토큰 구분 로직 구현 #89 

닫을 이슈 번호: resolved #89 

## 📌 반영 브랜치

> feat/#89 -> dev

## 📋 내용

> 카카오 로그인을 이용해 나온 토큰과 자체 로그인을 해서 나온 토큰을 구분하는 로직을 구현했습니다.

### 🖼️ 스크린샷 (선택)

> ex) 로그인 API 요청 swagger 사진

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
