### PR TITLE
[feat] 제출 (공지 확인) 기능 구현

### DIFF
--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -11,6 +11,7 @@ import {
   postCommentSer,
   deleteCommentSer,
   getSubmitRequirementsSer,
+  postSubmitService,
 } from "./room.service.js";
 
 export const fixPost = async (req, res, next) => {
@@ -133,6 +134,24 @@ export const getSubmitRequirements = async (req, res, next) => {
     console.log("postId: ", postId);
 
     const result = await getSubmitRequirementsSer(postId);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const postSubmit = async (req, res, next) => {
+  try {
+    const postId = req.params.postId;
+    const userId = req.user.userId;
+    const content = req.body.content;
+    const imageURLs = req.body.imageURLs;
+    console.log("postId: ", postId);
+    console.log("userId: ", userId);
+    console.log("content: ", content);
+    console.log("imageURLs: ", imageURLs);
+
+    const result = await postSubmitService(postId, userId, content, imageURLs);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -146,10 +146,7 @@ export const postSubmit = async (req, res, next) => {
     const userId = req.user.userId;
     const content = req.body.content;
     const imageURLs = req.body.imageURLs;
-    console.log("postId: ", postId);
-    console.log("userId: ", userId);
-    console.log("content: ", content);
-    console.log("imageURLs: ", imageURLs);
+    console.log("공지 확인 제출");
 
     const result = await postSubmitService(postId, userId, content, imageURLs);
     res.status(200).json(response(status.SUCCESS, result));

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -8,6 +8,7 @@ import {
   postCommentDao,
   deleteCommentDao,
   getSubmitRequirementsDao,
+  postSubmitDAO,
 } from "./room.dao.js";
 
 import {
@@ -127,4 +128,22 @@ export const getSubmitRequirementsSer = async (postId) => {
   }
 
   return postData;
+};
+
+export const postSubmitService = async (postId, userId, content, imageURLs) => {
+  const submitData = await postSubmitDAO(postId, userId, content, imageURLs);
+
+  if (submitData == -1) {
+    throw new Error("공지글을 찾을 수 없습니다.");
+  }
+
+  if (submitData == -2) {
+    throw new Error("Quiz에 제출하기 위한 답변 내용이 없습니다.");
+  }
+
+  if (submitData == -3) {
+    throw new Error("Mission에 제출하기 위한 사진이 없습니다.");
+  }
+
+  return submitData;
 };

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -133,3 +133,35 @@ export const getSubmitRequirementsSQL = `
   FROM post
   WHERE id = ?
 `;
+
+//제출 생성 (기존 제출 존재시 업데이트)
+export const postSubmitSQL = `
+  INSERT INTO submit (post_id, user_id, content, submit_state) VALUES (?, ?, ?, ?)
+  ON DUPLICATE KEY UPDATE content = ?, submit_state = ?
+`;
+
+//공지글의 안 읽은 인원수 1 감소
+export const decreaseUnreadCountOneByPostId = `
+  UPDATE post p
+  SET p.unread_count = p.unread_count - 1
+  WHERE p.id = ?
+`;
+
+//제출이미지 생성
+export const postSubmitImageSQL = `
+  INSERT INTO \`submit-image\` (submit_id, URL) VALUES (?, ?)
+`;
+
+//이전 제출이미지 삭제 (Soft Delete)
+export const deletePreviousSubmitImageSQL = `
+  UPDATE \`submit-image\` si
+  JOIN submit s ON s.post_id = ? AND s.user_id = ?
+  SET si.state = 'DELETED'
+  WHERE si.submit_id = s.id
+`;
+
+//포스트 ID와 유저 ID로 제출 ID 찾기
+export const getSubmitIdByPostIdAndUserId = `
+  SELECT id FROM submit s
+  WHERE post_id = ? AND user_id = ?
+`;

--- a/routes/room.route.js
+++ b/routes/room.route.js
@@ -11,6 +11,7 @@ import {
   postComment,
   deleteComment,
   getSubmitRequirements,
+  postSubmit,
 } from "../domains/room/room.controller.js";
 
 import { tokenAuth } from "../middleware/token.auth.js";
@@ -26,3 +27,4 @@ roomRouter.get("/post/:postId/comment", tokenAuth, expressAsyncHandler(getCommen
 roomRouter.post("/post/:postId/comment", tokenAuth, expressAsyncHandler(postComment));
 roomRouter.delete("/post/comment/:commentId", tokenAuth, expressAsyncHandler(deleteComment));
 roomRouter.get("/post/:postId/submit", tokenAuth, expressAsyncHandler(getSubmitRequirements));
+roomRouter.post("/post/:postId/submit", tokenAuth, expressAsyncHandler(postSubmit));

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -476,3 +476,61 @@ paths:
                         question:
                           type: string
                           description: 해당 포스트의 퀴즈/미션 제출 요구사항
+    post:
+      tags:
+        - room
+      summary: 공지글 퀴즈/미션 답변 및 인증사진 제출
+      description: 공지글 퀴즈/미션 답변 및 인증사진 제출
+      operationId: postSubmit
+      consumes:
+        - application/json  
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: postId
+          in: path
+          schema:
+            type: number
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+                  description: 퀴즈/미션에 제출할 답변 (퀴즈에서는 필수, 미션에서는 NULL 가능)
+                imageURLs:
+                  type: array
+                  description: 미션에 제출할 답변 (퀴즈에서는 NULL, 미션에서는 필수)
+                  example: ["https://image1.jpeg", "https://image2.jpeg", "https://image3.jpeg"]
+                  items:
+                    type: string    
+      responses:
+        "200":
+          description: 제출 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: object
+                    properties:
+                      submitId:
+                        type: number
+                        description: 제출 ID
+                      submitState:
+                        type: string
+                        description: 제출 상태 (퀴즈의 경우 정답 여부에 따라 COMPLETE / NOT_COMPLETE, 미션의 경우 PENDING)


### PR DESCRIPTION
# 🚩 관련 이슈

> [FEAT] 제출 (공지 확인) 기능 구현 #94 

닫을 이슈 번호: resolved #94 
## 📌 반영 브랜치

> feat/#94 -> dev

## 📋 내용

> 제출 (공지 확인) 기능 구현

> 주의사항 : SQL DB의 Submit 테이블 (POST_ID, USER_ID) 쌍 UNIQUE 설정, Submit-Image 테이블 URL 글자수 100자 이상으로 확장 설정 없을시 에러 발생 가능!

### 🖼️ 스크린샷 (선택)

>

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
