### PR TITLE
[fix] 공지방 메인 미확인 공지글 및 댓글 생성시간 기준으로 변경

### DIFF
--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -37,7 +37,7 @@ export const notCheckedPostInRoomDTO = (data) => {
     roomName: post.room_name,
     postId: post.id,
     postTitle: post.title,
-    updatedAtBefore: elapsedTime(post.updatedAtBeforeSec),
+    createdAtBefore: elapsedTime(post.createdAtBeforeSec),
   }));
 
   return { posts };
@@ -85,7 +85,7 @@ export const allCommentsInPostDTO = (data) => {
     commentId: comment.id,
     commentAuthorNickname: comment.nickname,
     commentBody: comment.content,
-    updatedAt: formatDate(comment.updated_at),
+    createdAt: formatDate(comment.created_at),
   }));
 
   return { data: comments, cursorId: data[data.length - 1].id };

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -56,12 +56,12 @@ export const getPostDetailsByRoomIdAtFirst = `
 
 //공지방 내 미확인 공지글 가져오기 (최신순 3개까지)
 export const getMyNotCheckedPostInRoom = `
-  SELECT p.id, r.room_name, p.title, TIMESTAMPDIFF(second, p.updated_at, CURRENT_TIMESTAMP) as updatedAtBeforeSec FROM post p
+  SELECT p.id, r.room_name, p.title, TIMESTAMPDIFF(second, p.created_at, CURRENT_TIMESTAMP) as createdAtBeforeSec FROM post p
   JOIN user u ON p.room_id = ? AND u.id = ?
   JOIN room r ON r.id = p.room_id
   LEFT JOIN submit s ON s.post_id = p.id AND s.user_id = u.id
   WHERE p.state = 'EXIST' AND (s.submit_state IS NULL OR s.submit_state = 'NOT_COMPLETE' OR s.submit_state = 'REJECT')
-  ORDER BY updatedAtBeforeSec ASC LIMIT 3
+  ORDER BY createdAtBeforeSec ASC LIMIT 3
 `;
 
 //개별 공지글 정보 가져오기
@@ -80,7 +80,7 @@ export const getPostImagesByPostId = `
 
 //공지글별 댓글 조회 (커서 없는 초기값)
 export const getCommentsByPostIdAtFirst = `
-  SELECT c.id, ur.nickname, c.content, c.updated_at FROM comment c
+  SELECT c.id, ur.nickname, c.content, c.created_at FROM comment c
   JOIN post p ON p.id = ? AND c.post_id = p.id
   LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id
   WHERE c.state = 'EXIST'
@@ -89,7 +89,7 @@ export const getCommentsByPostIdAtFirst = `
 
 //공지글별 댓글 조회 (커서 존재)
 export const getCommentsByPostId = `
-  SELECT c.id, ur.nickname, c.content, c.updated_at FROM comment c
+  SELECT c.id, ur.nickname, c.content, c.created_at FROM comment c
   JOIN post p ON p.id = ? AND c.post_id = p.id
   LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id
   WHERE c.state = 'EXIST' AND c.id > ?

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -183,19 +183,19 @@ paths:
                             "roomName": "README",
                             "postId": 6,
                             "postTitle": "test6",
-                            "updatedAtBefore": "1분 전",
+                            "createdAtBefore": "1분 전",
                         },
                         {
                             "roomName": "README",
                             "postId": 4,
                             "postTitle": "test4",
-                            "updatedAtBefore": "2개월 전",
+                            "createdAtBefore": "2개월 전",
                         },
                         {
                             "roomName": "README",
                             "postId": 3,
                             "postTitle": "test3",
-                            "updatedAtBefore": "4년 전",
+                            "createdAtBefore": "4년 전",
                         }
                       ]
                     }
@@ -311,31 +311,31 @@ paths:
                             "commentId": 1,
                             "commentAuthorNickname": "kimroom1",
                             "commentBody": "com.con.1",
-                            "updatedAt": "24. 7. 27. 18:08",
+                            "createdAt": "24. 7. 27. 18:08",
                         },
                         {
                             "commentId": 3,
                             "commentAuthorNickname": "parkroom1",
                             "commentBody": "com.con.3",
-                            "updatedAt": "24. 7. 27. 18:09",
+                            "createdAt": "24. 7. 27. 18:09",
                         },
                         {
                             "commentId": 4,
                             "commentAuthorNickname": "leeroom1",
                             "commentBody": "com.con.4",
-                            "updatedAt": "24. 7. 27. 18:09",
+                            "createdAt": "24. 7. 27. 18:09",
                         },
                         {
                             "commentId": 5,
                             "commentAuthorNickname": null,
                             "commentBody": "com.con.5",
-                            "updatedAt": "24. 7. 27. 18:10",
+                            "createdAt": "24. 7. 27. 18:10",
                         },
                         {
                             "commentId": 7,
                             "commentAuthorNickname": "leeroom1",
                             "commentBody": "com.con.7",
-                            "updatedAt": "24. 7. 27. 18:11",
+                            "createdAt": "24. 7. 27. 18:11",
                         }
                       ],
                     "cursorId": 7,


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 공지방 메인 미확인 공지글 및 댓글 생성시간 기준으로 변경 #132 

닫을 이슈 번호: resolved #132 

## 📌 반영 브랜치

> fix/#132 -> dev

## 📋 내용

> 공지방 메인 미확인 공지글 및 댓글 생성시간 기준으로 변경 (SQL, DTO, Swagger 수정)

### 🖼️ 스크린샷 (선택)

>

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
