### PR TITLE
[feat] 공지방별 닉네임 중복 확인 기능 구현

### DIFF
--- a/domains/user/user.controller.js
+++ b/domains/user/user.controller.js
@@ -16,6 +16,7 @@ import {
   verifyUserPassword,
   updatePassword,
   updateRoomProfile,
+  checkRoomDuplicateNickname,
 } from "./user.service.js";
 
 export const userSignUp = async (req, res, next) => {

--- a/domains/user/user.controller.js
+++ b/domains/user/user.controller.js
@@ -267,3 +267,18 @@ export const getUserJoinRoom = async (req, res, next) => {
     next(error);
   }
 };
+
+export const checkUserRoomNicknameDuplicate = async (req, res, next) => {
+  try {
+    console.log("공지방 내 닉네임 중복 확인");
+
+    const roomId = req.params.roomId;
+    const { nickname } = req.body;
+
+    const isDuplicate = await checkRoomDuplicateNickname(roomId, nickname);
+
+    res.status(200).json(response(status.SUCCESS, { isDuplicate }));
+  } catch (error) {
+    next(error);
+  }
+};

--- a/domains/user/user.dao.js
+++ b/domains/user/user.dao.js
@@ -17,6 +17,7 @@ import {
   updateUserRoomProfile,
   selectAdminId,
   updateRoomAdminNickname,
+  checkDuplicateNickname,
 } from "./user.sql.js";
 
 export const insertUser = async (data) => {
@@ -201,6 +202,19 @@ export const findJoinRoomByUserId = async (userId, page, pageSize) => {
     return { rooms, isNext };
   } catch (error) {
     console.log("내가 입장한 공지방 찾기 에러", error);
+    throw new BaseError(status.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const findDuplicateNickname = async (roomId, nickname) => {
+  try {
+    const conn = await pool.getConnection();
+    const [[{ count }]] = await conn.query(checkDuplicateNickname, [roomId, nickname]);
+
+    conn.release();
+    return count > 0;
+  } catch (error) {
+    console.log("중복 닉네임 확인 에러", error);
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
   }
 };

--- a/domains/user/user.service.js
+++ b/domains/user/user.service.js
@@ -9,6 +9,7 @@ import {
   updateUserProfileById,
   updateUserPasswordById,
   updateUserRoomProfileById,
+  findDuplicateNickname,
 } from "./user.dao.js";
 import { passwordHashing } from "../../utils/passwordHash.js";
 import { generateJWTToken } from "../../utils/generateToken.js";

--- a/domains/user/user.service.js
+++ b/domains/user/user.service.js
@@ -222,3 +222,9 @@ export const getMyJoinRoom = async (userId, page, pageSize) => {
 
   return { rooms: Myrooms, isNext };
 };
+
+export const checkRoomDuplicateNickname = async (roomId, nickname) => {
+  const isDuplicate = await findDuplicateNickname(roomId, nickname);
+
+  return isDuplicate;
+};

--- a/domains/user/user.sql.js
+++ b/domains/user/user.sql.js
@@ -105,3 +105,10 @@ export const getJoinRoom = `
   LIMIT ?
   OFFSET ?
 `;
+
+// 닉네임 중복 확인
+export const checkDuplicateNickname = `
+  SELECT COUNT(*) as count
+  FROM \`user-room\`
+  WHERE room_id = ? AND nickname = ?
+`;

--- a/routes/user.route.js
+++ b/routes/user.route.js
@@ -17,6 +17,7 @@ import {
   getUserPassword,
   updateUserPassword,
   updateUserRoomProfile,
+  checkUserRoomNicknameDuplicate,
 } from "../domains/user/user.controller.js";
 import { tokenAuth } from "../middleware/token.auth.js";
 import { imageUploader } from "../middleware/image.uploader.js";
@@ -53,6 +54,12 @@ userRouter.get("/profile", tokenAuth, expressAsyncHandler(getUserRoomProfiles));
 userRouter.patch("/profile", tokenAuth, expressAsyncHandler(updateUserBasicProfile));
 
 userRouter.patch("/profile/:roomId", tokenAuth, expressAsyncHandler(updateUserRoomProfile));
+
+userRouter.post(
+  "/profile/:roomId/nickname",
+  tokenAuth,
+  expressAsyncHandler(checkUserRoomNicknameDuplicate)
+);
 
 userRouter.post("/password", tokenAuth, expressAsyncHandler(getUserPassword));
 

--- a/swagger/user.swagger.yaml
+++ b/swagger/user.swagger.yaml
@@ -678,6 +678,58 @@ paths:
                       isSuccess:
                         type: boolean
                         description: 수정 성공 여부
+
+  /user/profile/{roomId}/nickname:
+    post:
+      tags:
+        - user
+      summary: 공지방별 닉네임 중복 확인
+      description: 공지방별 닉네임 중복 확인
+      operationId: user-room-nickname
+      consumes:
+        - application/json
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: roomId
+          required: true
+          schema:
+            type: string
+            description: 닉네임 중복을 확인 할 공지방의 아이디
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nickname:
+                  type: string
+                  description: 닉네임
+      responses:
+        "200":
+          description: 공지방별 닉네임 중복 확인 성공!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: object
+                    properties:
+                      isDuplicate:
+                        type: boolean
+                        description: true (중복 발생) / false (중복 X)
   
   /user/password:
     post:


### PR DESCRIPTION
# 🚩 관련 이슈

> [feat] 공지방별 닉네임 중복 확인 기능 구현 #105

닫을 이슈 번호: resolved #105

## 📌 반영 브랜치

> feat/#105 -> dev

## 📋 내용

> 공지방별 닉네임 중복 확인 기능 구현

### 🖼️ 스크린샷 (선택)

> <img width="1300" alt="스크린샷 2024-08-06 오후 2 31 18" src="https://github.com/user-attachments/assets/da8400c5-24bc-4ca2-8046-0ba84d255004">


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 
