### PR TITLE
[feat] 공지방 입장시 비밀번호 일치 확인 기능 구현

### DIFF
--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -13,6 +13,7 @@ import {
   getSubmitRequirementsService,
   postSubmitService,
   getRoomEntranceService,
+  checkPasswordService,
 } from "./room.service.js";
 
 export const fixPost = async (req, res, next) => {
@@ -162,6 +163,19 @@ export const getRoomEntrance = async (req, res, next) => {
     console.log("최초 입장시 공지방 정보 조회");
 
     const result = await getRoomEntranceService(roomId);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const checkPassword = async (req, res, next) => {
+  try {
+    const roomId = req.params.roomId;
+    const passwordInput = req.body.content;
+    console.log("최초 입장시 공지방 정보 조회");
+
+    const result = await checkPasswordService(roomId, passwordInput);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -25,6 +25,7 @@ import {
   deletePreviousSubmitImageSQL,
   getSubmitIdByPostIdAndUserId,
   getRoomEntranceInfoByRoomId,
+  checkRoomPasswordSQL,
 } from "./room.sql.js";
 import { getUserById } from "../user/user.sql.js";
 
@@ -368,6 +369,25 @@ export const getRoomEntranceDAO = async (roomId) => {
     }
     conn.release();
     return roomInfo[0];
+  } catch (err) {
+    throw new BaseError(status.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const checkPasswordDAO = async (roomId, passwordInput) => {
+  try {
+    const conn = await pool.getConnection();
+
+    const [room] = await conn.query(getRoomById, roomId);
+
+    if (room.length == 0) {
+      conn.release();
+      return -1;
+    }
+
+    const [isValid] = await conn.query(checkRoomPasswordSQL, [passwordInput, roomId]);
+    conn.release();
+    return isValid[0].isValidResult;
   } catch (err) {
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
   }

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -10,6 +10,7 @@ import {
   getSubmitRequirementsDAO,
   postSubmitDAO,
   getRoomEntranceDAO,
+  checkPasswordDAO,
 } from "./room.dao.js";
 
 import {
@@ -164,4 +165,20 @@ export const getRoomEntranceService = async (roomId) => {
   }
 
   return roomData;
+};
+
+export const checkPasswordService = async (roomId, passwordInput) => {
+  const roomData = await checkPasswordDAO(roomId, passwordInput);
+
+  if (roomData == -1) {
+    throw new Error("공지방을 찾을 수 없습니다.");
+  }
+
+  if (roomData == 0) {
+    return { isValid: false };
+  }
+
+  if (roomData == 1) {
+    return { isValid: true };
+  }
 };

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -170,3 +170,8 @@ export const getSubmitIdByPostIdAndUserId = `
 export const getRoomEntranceInfoByRoomId = `
   SELECT room_name, room_image, admin_nickname FROM room WHERE id = ?
 `;
+
+//공지방 비밀번호가 일치하는지 여부 확인
+export const checkRoomPasswordSQL = `
+  SELECT BINARY r.room_password = ? AS isValidResult FROM room r WHERE r.id = ?
+`;

--- a/routes/room.route.js
+++ b/routes/room.route.js
@@ -13,6 +13,7 @@ import {
   getSubmitRequirements,
   postSubmit,
   getRoomEntrance,
+  checkPassword,
 } from "../domains/room/room.controller.js";
 
 import { tokenAuth } from "../middleware/token.auth.js";
@@ -30,3 +31,4 @@ roomRouter.delete("/post/comment/:commentId", tokenAuth, expressAsyncHandler(del
 roomRouter.get("/post/:postId/submit", tokenAuth, expressAsyncHandler(getSubmitRequirements));
 roomRouter.post("/post/:postId/submit", tokenAuth, expressAsyncHandler(postSubmit));
 roomRouter.get("/enter/:roomId", tokenAuth, expressAsyncHandler(getRoomEntrance));
+roomRouter.post("/:roomId/checkPassword", tokenAuth, expressAsyncHandler(checkPassword));

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -581,3 +581,55 @@ paths:
                         admin_nickname:
                           type: string
                           description: 해당 공지방 관리자 닉네임
+
+  /room/{roomId}/checkPassword:
+    post:
+      tags:
+        - room
+      summary: 공지방 입장시 비밀번호 일치여부 확인
+      description: 공지방 입장시 비밀번호 일치여부 확인
+      operationId: checkRoomPassword
+      consumes:
+        - application/json  
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: roomId
+          in: path
+          schema:
+            type: number
+          required: true    
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+                  description: 사용자가 입력한 비밀번호
+      responses:
+        "200":
+          description: 공지방 최초 입장시 공지방 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: object
+                    properties:
+                        isValid:
+                          type: boolean
+                          example: true
+                          description: 비밀번호 일치 여부


### PR DESCRIPTION
# 🚩 관련 이슈

> [feat] 공지방 입장시 비밀번호 일치 확인 기능 구현 #138 

닫을 이슈 번호: resolved #138 

## 📌 반영 브랜치

> feat/#138 -> dev

## 📋 내용

> 공지방 입장시 비밀번호 일치 확인 기능 구현
> SQL 레벨에서 비밀번호 비교
> 일치하면 true, 일치하지 않으면 false 반환

### 🖼️ 스크린샷 (선택)

> 
![image](https://github.com/user-attachments/assets/023be018-3fbc-4baf-a84e-0e9a5521a740)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
