### PR TITLE
[fix] 댓글 조회시 내가 작성한 댓글인지 여부 리턴값 추가

### DIFF
--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -91,9 +91,10 @@ export const getDetailedPost = async (req, res, next) => {
 export const getComments = async (req, res, next) => {
   try {
     const postId = req.params.postId;
+    const userId = req.user.userId;
     console.log("postId: ", postId);
 
-    const result = await getCommentsService(postId, req.query);
+    const result = await getCommentsService(postId, userId, req.query);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -14,6 +14,7 @@ import {
   postSubmitService,
   getRoomEntranceService,
   checkPasswordService,
+  postRoomEntranceService,
 } from "./room.service.js";
 
 export const fixPost = async (req, res, next) => {
@@ -176,6 +177,20 @@ export const checkPassword = async (req, res, next) => {
     console.log("최초 입장시 공지방 정보 조회");
 
     const result = await checkPasswordService(roomId, passwordInput);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const postRoomEntrance = async (req, res, next) => {
+  try {
+    const roomId = req.params.roomId;
+    const userId = req.user.userId;
+    const userNickname = req.body.nickname;
+    console.log("공지방 입장 등록");
+
+    const result = await postRoomEntranceService(roomId, userId, userNickname);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -47,9 +47,8 @@ export const fixPostDAO = async (data) => {
       return -2;
     }
 
-    const result = await conn.query(changeFixedPostSQL, [data.postId, data.userId]);
+    await conn.query(changeFixedPostSQL, [data.postId, data.userId]);
 
-    console.log(result);
     conn.release();
     return "고정 공지글 등록 성공";
   } catch (error) {
@@ -69,9 +68,8 @@ export const deleteFixPostDAO = async (data) => {
       return -1;
     }
 
-    const result = await conn.query(changeFixedPostSQL, [null, data.userId]);
+    await conn.query(changeFixedPostSQL, [null, data.userId]);
 
-    console.log(result);
     conn.release();
     return "고정 공지글 삭제 성공";
   } catch (error) {

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -26,6 +26,7 @@ import {
   getSubmitIdByPostIdAndUserId,
   getRoomEntranceInfoByRoomId,
   checkRoomPasswordSQL,
+  createRoomEntranceSQL,
 } from "./room.sql.js";
 import { getUserById } from "../user/user.sql.js";
 
@@ -388,6 +389,25 @@ export const checkPasswordDAO = async (roomId, passwordInput) => {
     const [isValid] = await conn.query(checkRoomPasswordSQL, [passwordInput, roomId]);
     conn.release();
     return isValid[0].isValidResult;
+  } catch (err) {
+    throw new BaseError(status.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const postRoomEntranceDAO = async (roomId, userId, userNickname) => {
+  try {
+    const conn = await pool.getConnection();
+
+    const [room] = await conn.query(getRoomById, roomId);
+
+    if (room.length == 0) {
+      conn.release();
+      return -1;
+    }
+
+    await conn.query(createRoomEntranceSQL, [userId, roomId, userNickname]);
+    conn.release();
+    return true;
   } catch (err) {
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
   }

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -80,9 +80,18 @@ export const detailedPostDTO = (data) => {
   return { post, imageURLs };
 };
 
-export const allCommentsInPostDTO = (data) => {
+export const allCommentsInPostDTO = (data, userId) => {
+  const isCommentMine = (myUserId, commentUserId) => {
+    if (myUserId === commentUserId) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   const comments = data.map((comment) => ({
     commentId: comment.id,
+    isCommentMine: isCommentMine(userId, comment.user_id),
     commentAuthorNickname: comment.nickname,
     commentBody: comment.content,
     createdAt: formatDate(comment.created_at),

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -11,6 +11,7 @@ import {
   postSubmitDAO,
   getRoomEntranceDAO,
   checkPasswordDAO,
+  postRoomEntranceDAO,
 } from "./room.dao.js";
 
 import {
@@ -181,4 +182,14 @@ export const checkPasswordService = async (roomId, passwordInput) => {
   if (roomData == 1) {
     return { isValid: true };
   }
+};
+
+export const postRoomEntranceService = async (roomId, userId, userNickname) => {
+  const userRoomData = await postRoomEntranceDAO(roomId, userId, userNickname);
+
+  if (userRoomData == -1) {
+    throw new Error("공지방을 찾을 수 없습니다.");
+  }
+
+  return { isSuccess: userRoomData };
 };

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -90,7 +90,7 @@ export const getDetailedPostService = async (postId, userId) => {
   return detailedPostDTO(roomData);
 };
 
-export const getCommentsService = async (postId, query) => {
+export const getCommentsService = async (postId, userId, query) => {
   const { commentId, size = 100 } = query;
 
   const postData = await getCommentsDAO(postId, commentId, size);
@@ -103,7 +103,7 @@ export const getCommentsService = async (postId, query) => {
     return null;
   }
 
-  return allCommentsInPostDTO(postData);
+  return allCommentsInPostDTO(postData, userId);
 };
 
 export const postCommentService = async (postId, userId, content) => {

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -1,21 +1,21 @@
 // 고정 공지글 변경
 export const changeFixedPostSQL = `
-  UPDATE user SET fixed_post_id = ? WHERE id = ?
+  UPDATE user SET fixed_post_id = ? WHERE id = ? AND state = 'EXIST'
 `;
 
 // ID 값으로 공지글 찾기
 export const getPostById = `
-  SELECT * FROM post WHERE id = ?
+  SELECT * FROM post WHERE id = ? AND state = 'EXIST'
 `;
 
 // ID 값으로 공지방 찾기
 export const getRoomById = `
-  SELECT * FROM room WHERE id = ?
+  SELECT * FROM room WHERE id = ? AND state = 'EXIST'
 `;
 
 //ID 값으로 댓글 찾기
 export const getCommentById = `
-  SELECT * FROM comment WHERE id = ?
+  SELECT * FROM comment WHERE id = ? AND state = 'EXIST'
 `;
 
 //공지방 내 공지글 정보, 나의 제출상태 가져오기 (커서 존재)
@@ -80,18 +80,18 @@ export const getPostImagesByPostId = `
 
 //공지글별 댓글 조회 (커서 없는 초기값)
 export const getCommentsByPostIdAtFirst = `
-  SELECT c.id, ur.nickname, c.content, c.created_at FROM comment c
+  SELECT c.id, c.user_id, ur.nickname, c.content, c.created_at FROM comment c
   JOIN post p ON p.id = ? AND c.post_id = p.id
-  LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id
+  LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id AND p.room_id = ur.room_id
   WHERE c.state = 'EXIST'
   ORDER BY c.id ASC LIMIT ?
 `;
 
 //공지글별 댓글 조회 (커서 존재)
 export const getCommentsByPostId = `
-  SELECT c.id, ur.nickname, c.content, c.created_at FROM comment c
+  SELECT c.id, c.user_id, ur.nickname, c.content, c.created_at FROM comment c
   JOIN post p ON p.id = ? AND c.post_id = p.id
-  LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id
+  LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id AND p.room_id = ur.room_id
   WHERE c.state = 'EXIST' AND c.id > ?
   ORDER BY c.id ASC LIMIT ?
 `;
@@ -168,7 +168,7 @@ export const getSubmitIdByPostIdAndUserId = `
 
 //공지방 최초 입장시 공지방 정보 가져오기
 export const getRoomEntranceInfoByRoomId = `
-  SELECT room_name, room_image, admin_nickname FROM room WHERE id = ?
+  SELECT room_name, room_image, admin_nickname FROM room WHERE id = ? AND state = 'EXIST'
 `;
 
 //공지방 비밀번호가 일치하는지 여부 확인

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -175,3 +175,8 @@ export const getRoomEntranceInfoByRoomId = `
 export const checkRoomPasswordSQL = `
   SELECT BINARY r.room_password = ? AS isValidResult FROM room r WHERE r.id = ?
 `;
+
+//공지방에 유저를 입장 등록
+export const createRoomEntranceSQL = `
+  INSERT INTO \`user-room\` (user_id, room_id, nickname) VALUES (?, ?, ?)
+`;

--- a/domains/user/user.dao.js
+++ b/domains/user/user.dao.js
@@ -21,6 +21,8 @@ import {
   getLatestPostInRoom,
   getAllRoomsCount,
   getSubmitCountInRoom,
+  getSubmitListInRoom,
+  getSubmitImages,
 } from "./user.sql.js";
 
 export const insertUser = async (data) => {
@@ -150,10 +152,11 @@ export const findFixedPostByUserId = async (userId) => {
   }
 };
 
-export const findRoomByUserId = async (userId) => {
+export const findRoomByUserId = async (userId, page, pageSize) => {
   try {
     const conn = await pool.getConnection();
-    const [rooms] = await conn.query(getAllRooms, [userId]);
+    const offset = (page - 1) * pageSize;
+    const [rooms] = await conn.query(getAllRooms, [userId, pageSize, offset]);
 
     if (rooms.length == 0) {
       conn.release();
@@ -267,6 +270,32 @@ export const findSubmitCountInRoom = async (roomId, userId) => {
     return submit_count;
   } catch (error) {
     console.log("제출 개수 찾기 에러", error);
+    throw new BaseError(status.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const findSubmitList = async (roomId) => {
+  try {
+    const conn = await pool.getConnection();
+    const [submits] = await conn.query(getSubmitListInRoom, [roomId]);
+
+    conn.release();
+    return submits;
+  } catch (error) {
+    console.log("Submit 목록 찾기 에러", error);
+    throw new BaseError(status.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const findSubmitImages = async (submitId) => {
+  try {
+    const conn = await pool.getConnection();
+    const [images] = await conn.query(getSubmitImages, [submitId]);
+
+    conn.release();
+    return images.map((image) => image.URL);
+  } catch (error) {
+    console.log("Submit 이미지 목록 찾기 에러", error);
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
   }
 };

--- a/domains/user/user.dao.js
+++ b/domains/user/user.dao.js
@@ -20,6 +20,7 @@ import {
   checkDuplicateNickname,
   getLatestPostInRoom,
   getAllRoomsCount,
+  getSubmitCountInRoom,
 } from "./user.sql.js";
 
 export const insertUser = async (data) => {
@@ -254,6 +255,18 @@ export const findLatestPostInRoom = async (roomId) => {
     return post[0];
   } catch (error) {
     console.log("가장 최근 공지글 찾기 에러", error);
+    throw new BaseError(status.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const findSubmitCountInRoom = async (roomId, userId) => {
+  try {
+    const conn = await pool.getConnection();
+    const [[{ submit_count }]] = await conn.query(getSubmitCountInRoom, [roomId, userId]);
+    conn.release();
+    return submit_count;
+  } catch (error) {
+    console.log("제출 개수 찾기 에러", error);
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
   }
 };

--- a/domains/user/user.service.js
+++ b/domains/user/user.service.js
@@ -14,6 +14,8 @@ import {
   findAllRooms,
   getRoomsCount,
   findSubmitCountInRoom,
+  findSubmitList,
+  findSubmitImages,
 } from "./user.dao.js";
 import { passwordHashing } from "../../utils/passwordHash.js";
 import { generateJWTToken } from "../../utils/generateToken.js";
@@ -156,14 +158,14 @@ export const getMyFixedPost = async (userId) => {
   };
 };
 
-export const getMyRoomProfiles = async (userId) => {
+export const getMyRoomProfiles = async (userId, page, pageSize) => {
   const userData = await findUserById(userId);
 
   if (!userData) {
     throw new Error("사용자를 찾을 수 없습니다.");
   }
 
-  const rooms = await findRoomByUserId(userId);
+  const rooms = await findRoomByUserId(userId, page, pageSize);
 
   if (!rooms) {
     return {
@@ -180,11 +182,11 @@ export const getMyRoomProfiles = async (userId) => {
 };
 
 export const getMyCreateRoom = async (userId, page, pageSize) => {
-  const userData = await findUserById(userId);
+  // const userData = await findUserById(userId);
 
-  if (!userData) {
-    throw new Error("사용자를 찾을 수 없습니다.");
-  }
+  // if (!userData) {
+  //   throw new Error("사용자를 찾을 수 없습니다.");
+  // }
 
   const { rooms, isNext } = await findCreateRoomByUserId(userId, page, pageSize);
 
@@ -193,7 +195,7 @@ export const getMyCreateRoom = async (userId, page, pageSize) => {
   }
 
   const Myrooms = rooms.map((room) => ({
-    id: room.id,
+    id: room.room_id,
     nickname: room.user_nickname,
     roomName: room.room_name,
     roomImage: room.room_image,
@@ -205,11 +207,11 @@ export const getMyCreateRoom = async (userId, page, pageSize) => {
 };
 
 export const getMyJoinRoom = async (userId, page, pageSize) => {
-  const userData = await findUserById(userId);
+  // const userData = await findUserById(userId);
 
-  if (!userData) {
-    throw new Error("사용자를 찾을 수 없습니다.");
-  }
+  // if (!userData) {
+  //   throw new Error("사용자를 찾을 수 없습니다.");
+  // }
 
   const { rooms, isNext } = await findJoinRoomByUserId(userId, page, pageSize);
 
@@ -267,4 +269,24 @@ export const getLatestPostsInAllRooms = async (userId, page, pageSize) => {
   const isNext = page * pageSize < totalCount;
 
   return { recentPostList, isNext };
+};
+
+export const getSubmitList = async (roomId) => {
+  const submits = await findSubmitList(roomId);
+
+  const detailedSubmitsPromises = submits.map(async (submit) => {
+    const images = await findSubmitImages(submit.submit_id);
+
+    return {
+      nickname: submit.user_nickname,
+      profileImage: submit.profile_image,
+      submitState: submit.submit_state,
+      content: submit.content,
+      images,
+    };
+  });
+
+  const detailedSubmits = await Promise.all(detailedSubmitsPromises);
+
+  return detailedSubmits;
 };

--- a/domains/user/user.sql.js
+++ b/domains/user/user.sql.js
@@ -103,9 +103,9 @@ export const getJoinRoomCount = `
   WHERE u.id = ? AND r.admin_id <> ?
 `;
 
-// 입장한 공지방 찾기
+// 내가 입장한 공지방 찾기
 export const getJoinRoom = `
-  SELECT room.id, ur.nickname as user_nickname, room.room_name, room.room_image, room.state, MAX(post.created_at) as latest_post_time
+  SELECT room.id as room_id, ur.nickname as user_nickname, room.room_name, room.room_image, room.state, room.max_penalty as max_penalty_count, ur.penalty_count, MAX(post.created_at) as latest_post_time
   FROM room
   JOIN \`user-room\` ur ON room.id = ur.room_id
   LEFT JOIN post ON room.id = post.room_id
@@ -129,4 +129,12 @@ export const getLatestPostInRoom = `
   WHERE p.room_id = ? AND p.state = 'EXIST'
   ORDER BY p.created_at DESC
   LIMIT 1
+`;
+
+// 공지방에 대한 내 submit (MISSION) 개수 찾기
+export const getSubmitCountInRoom = `
+  SELECT COUNT(*) as submit_count
+  FROM submit s
+  JOIN post p ON s.post_id = p.id
+  WHERE p.room_id = ? AND s.user_id = ? AND s.submit_state IN ('COMPLETE', 'PENDING', 'REJECT') AND p.type = 'MISSION'
 `;

--- a/domains/user/user.sql.js
+++ b/domains/user/user.sql.js
@@ -59,7 +59,7 @@ export const getFixedPost = `
 // 모든 공지방 찾기 (내가 개설한 공지방과 입장한 공지방)
 export const getAllRooms = `
   SELECT ur.nickname, ur.profile_image, r.room_name, r.id, r.admin_id
-  FROM \`user-room\` ur 
+  FROM \`user-room\` ur
   JOIN room r ON r.id = ur.room_id
   WHERE ur.user_id = ?
   LIMIT ?
@@ -77,19 +77,19 @@ export const getAllRoomsCount = `
 // 개설한 공지방 개수 구하기
 export const getCreateRoomCount = `
   SELECT COUNT(*) as count
-  FROM user u
-  JOIN room r ON u.id = r.admin_id
-  WHERE u.id = ?
+  FROM \`user-room\` ur
+  JOIN user u ON u.id = ur.user_id
+  JOIN room r ON r.id = ur.room_id
+  WHERE r.admin_id = ?
 `;
 
 // 개설한 공지방 찾기
 export const getCreateRoom = `
-  SELECT room.id, ur.nickname as user_nickname, room.room_name, room.room_image, room.state, MAX(post.created_at) as latest_post_time
-  FROM room
-  JOIN \`user-room\` ur ON room.id = ur.room_id AND ur.user_id = room.admin_id
-  LEFT JOIN post ON room.id = post.room_id
-  WHERE room.admin_id = ?
-  GROUP BY room.id, ur.nickname
+  SELECT r.id as room_id, r.admin_nickname as user_nickname, r.room_name, r.room_image, r.state, MAX(post.created_at) as latest_post_time
+  FROM room r
+  LEFT JOIN post ON r.id = post.room_id
+  WHERE  r.admin_id = ?
+  GROUP BY r.id
   LIMIT ?
   OFFSET ?
 `;
@@ -137,4 +137,20 @@ export const getSubmitCountInRoom = `
   FROM submit s
   JOIN post p ON s.post_id = p.id
   WHERE p.room_id = ? AND s.user_id = ? AND s.submit_state IN ('COMPLETE', 'PENDING', 'REJECT') AND p.type = 'MISSION'
+`;
+
+// 공지방에 대한 내 submit 목록 조회하기
+export const getSubmitListInRoom = `
+  SELECT s.id as submit_id, s.submit_state, s.content, ur.nickname as user_nickname, ur.profile_image
+  FROM submit s
+  JOIN post p ON s.post_id = p.id
+  JOIN \`user-room\` ur ON ur.user_id = s.user_id AND ur.room_id = p.room_id
+  WHERE p.room_id = ? AND p.type = 'MISSION'
+`;
+
+// Sumbit에 대한 Submit-Image 목록 조회하기
+export const getSubmitImages = `
+  SELECT si.URL
+  FROM \`submit-image\` si
+  WHERE si.submit_id = ?
 `;

--- a/routes/room.route.js
+++ b/routes/room.route.js
@@ -13,6 +13,7 @@ import {
   getSubmitRequirements,
   postSubmit,
   getRoomEntrance,
+  postRoomEntrance,
   checkPassword,
 } from "../domains/room/room.controller.js";
 
@@ -31,4 +32,5 @@ roomRouter.delete("/post/comment/:commentId", tokenAuth, expressAsyncHandler(del
 roomRouter.get("/post/:postId/submit", tokenAuth, expressAsyncHandler(getSubmitRequirements));
 roomRouter.post("/post/:postId/submit", tokenAuth, expressAsyncHandler(postSubmit));
 roomRouter.get("/enter/:roomId", tokenAuth, expressAsyncHandler(getRoomEntrance));
+roomRouter.post("/enter/:roomId", tokenAuth, expressAsyncHandler(postRoomEntrance));
 roomRouter.post("/:roomId/checkPassword", tokenAuth, expressAsyncHandler(checkPassword));

--- a/routes/user.route.js
+++ b/routes/user.route.js
@@ -19,6 +19,7 @@ import {
   updateUserRoomProfile,
   checkUserRoomNicknameDuplicate,
   getLatestPosts,
+  getMySubmitList,
 } from "../domains/user/user.controller.js";
 import { tokenAuth } from "../middleware/token.auth.js";
 import { imageUploader } from "../middleware/image.uploader.js";
@@ -67,3 +68,5 @@ userRouter.post(
 userRouter.post("/password", tokenAuth, expressAsyncHandler(getUserPassword));
 
 userRouter.patch("/password", tokenAuth, expressAsyncHandler(updateUserPassword));
+
+userRouter.get("/rooms/missions/:roomId", tokenAuth, expressAsyncHandler(getMySubmitList));

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -581,6 +581,56 @@ paths:
                         admin_nickname:
                           type: string
                           description: 해당 공지방 관리자 닉네임
+    post:
+      tags:
+        - room
+      summary: 공지방 입장 등록
+      description: 공지방 최초 입장 확정하여 유저를 user-room 테이블에 등록
+      operationId: postRoomEntrance
+      consumes:
+        - application/json  
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: roomId
+          in: path
+          schema:
+            type: number
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nickname:
+                  type: string
+                  description: 해당 방에서 사용할 사용자가 입력한 닉네임
+      responses:
+        "200":
+          description: 공지방 입장 등록 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: object
+                    properties:
+                        isSuccess:
+                          type: boolean
+                          example: true
+                          description: 공지방에 유저 등록 성공
 
   /room/{roomId}/checkPassword:
     post:

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -246,7 +246,7 @@ paths:
                             "startDate": "24. 7. 25. 04:24",
                             "endDate": "24. 7. 25. 05:24",
                             "commentCount": 5,
-                            "submitState": "complete",
+                            "submitState": "COMPLETE",
                         }
                       ],
                       "imageURLs": [
@@ -308,37 +308,56 @@ paths:
                     example: {
                       "data": [
                         {
-                            "commentId": 1,
-                            "commentAuthorNickname": "kimroom1",
-                            "commentBody": "com.con.1",
-                            "createdAt": "24. 7. 27. 18:08",
+                          "commentId": 1,
+                          "isCommentMine": false,
+                          "commentAuthorNickname": "kimroom1",
+                          "commentBody": "com.con.1",
+                          "createdAt": "24. 7. 27. 18:08",
                         },
                         {
-                            "commentId": 3,
-                            "commentAuthorNickname": "parkroom1",
-                            "commentBody": "com.con.3",
-                            "createdAt": "24. 7. 27. 18:09",
+                          "commentId": 3,
+                          "isCommentMine": false,
+                          "commentAuthorNickname": "parkroom1",
+                          "commentBody": "com.con.3",
+                          "createdAt": "24. 7. 27. 18:09",
                         },
                         {
-                            "commentId": 4,
-                            "commentAuthorNickname": "leeroom1",
-                            "commentBody": "com.con.4",
-                            "createdAt": "24. 7. 27. 18:09",
+                          "commentId": 4,
+                          "isCommentMine": true,
+                          "commentAuthorNickname": "leeroom1",
+                          "commentBody": "com.con.4",
+                          "createdAt": "24. 7. 27. 18:09",
                         },
                         {
-                            "commentId": 5,
-                            "commentAuthorNickname": null,
-                            "commentBody": "com.con.5",
-                            "createdAt": "24. 7. 27. 18:10",
+                          "commentId": 5,
+                          "isCommentMine": false,
+                          "commentAuthorNickname": null,
+                          "commentBody": "com.con.5",
+                          "createdAt": "24. 7. 27. 18:10",
                         },
                         {
-                            "commentId": 7,
-                            "commentAuthorNickname": "leeroom1",
-                            "commentBody": "com.con.7",
-                            "createdAt": "24. 7. 27. 18:11",
+                          "commentId": 7,
+                          "isCommentMine": true,
+                          "commentAuthorNickname": "leeroom1",
+                          "commentBody": "com.con.7",
+                          "createdAt": "24. 7. 27. 18:11",
+                        },
+                        {
+                          "commentId": 11,
+                          "isCommentMine": false,
+                          "commentAuthorNickname": "parkroom1",
+                          "commentBody": "testcontent",
+                          "createdAt": "24. 8. 1. 16:22",
+                        },
+                        {
+                          "commentId": 12,
+                          "isCommentMine": false,
+                          "commentAuthorNickname": "parkroom1",
+                          "commentBody": "testcontent",
+                          "createdAt": "24. 8. 1. 16:22",
                         }
                       ],
-                    "cursorId": 7,
+                      "cursorId": 12,
                     }
     post:
       tags:

--- a/swagger/user.swagger.yaml
+++ b/swagger/user.swagger.yaml
@@ -572,7 +572,7 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
+                              type: number
                               description: 공지방 ID
                             nickname:
                               type: string
@@ -589,6 +589,15 @@ paths:
                             latestPostTime:
                               type: string
                               description: 공지방의 최근 공지글 작성 시간
+                            submitCount:
+                              type: number
+                              description: 내가 제출한 요청 내역 개수 (NotComplete 제외)
+                            maxPenaltyCount:
+                              type: number
+                              description: 해당 공지방의 최대 페널티 개수
+                            penaltyCount:
+                              type: number
+                              description: 해당 공지방의 내 페널티 개수
                       isNext:
                         type: boolean
                         description: 다음 페이지가 있는지 여부

--- a/swagger/user.swagger.yaml
+++ b/swagger/user.swagger.yaml
@@ -900,3 +900,61 @@ paths:
                       isSuccess:
                         type: boolean
                         description: 수정 성공 여부
+  
+  /user/rooms/missions/{roomId}:
+    get:
+      tags:
+        - user
+      summary: 공지방마다 제출한 미션 내역 조회
+      description: 공지방마다 제출한 미션 내역 조회
+      operationId: user-room-missions
+      consumes:
+        - application/json
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: roomId
+          required: true
+          schema:
+            type: integer
+            description: 미션 제출 내역을 확인 할 공지방의 아이디
+      responses:
+        "200":
+          description: 공지방마다 제출한 미션 내역 조회 성공!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        nickname:
+                          type: string
+                          description: 해당 공지방에서의 닉네임
+                        profileImage:
+                          type: string
+                          description: 해당 공지방에서의 프로필 사진
+                        submitState:
+                          type: string
+                          description: 해당 제출의 상태 (COMPLETE, PENDING, REJECT)
+                        content:
+                          type: string
+                          description: 해당 제출의 기타사항
+                        images:
+                          type: array
+                          items:
+                            type: string
+                            description: 이미지 URL


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 댓글 조회시 내가 작성한 댓글인지 여부 리턴값 추가 #149 

닫을 이슈 번호: resolved #149 

## 📌 반영 브랜치

> feat/#149 -> dev

## 📋 내용

> 댓글 조회시 내가 작성한 댓글인지 여부 리턴값 추가 (isCommentMine: true/false)

> 댓글 조회시 SQL 로직 오류로 잘못된 값 조회되는 부분 수정

> 각종 조회에서 Soft Delete된 값 조회되지 않도록 SQL에 EXIST 조건 추가 (이미 삭제된 댓글이 다시 삭제 요청되어 Post의 댓글 카운트가 비정상적으로 줄어드는 문제 해결)

> 해당 내용 Swagger 추가 및 공지방 내 미확인 공지글 조회 Swagger 예시에서 Submit State가 최신화되지 않아 소문자로 나오는 오류 해결

> 불필요한 console.log 제거

### 🖼️ 스크린샷 (선택)

> ![image](https://github.com/user-attachments/assets/3d7cd893-9158-4761-9e6f-ff7fcaf7f78b)

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
