### PR TITLE
[fix] 각종 조회시 리턴값 추가

### DIFF
--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -112,7 +112,7 @@ export const getAllPostInRoomDAO = async (roomId, userId, cursorId, size) => {
         return -2;
       }
       conn.release();
-      return posts;
+      return { isRoomAdmin, posts };
     }
   } catch (err) {
     throw new BaseError(status.INTERNAL_SERVER_ERROR);

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -89,6 +89,9 @@ export const getAllPostInRoomDAO = async (roomId, userId, cursorId, size) => {
       return -1;
     }
 
+    const isRoomAdmin = userId === room[0].admin_id;
+    console.log(isRoomAdmin);
+
     if (cursorId == "undefined" || typeof cursorId == "undefined" || cursorId == null) {
       const [posts] = await pool.query(getPostDetailsByRoomIdAtFirst, [+roomId, +userId, +size]);
       if (posts.length == 0) {
@@ -96,7 +99,7 @@ export const getAllPostInRoomDAO = async (roomId, userId, cursorId, size) => {
         return -2;
       }
       conn.release();
-      return posts;
+      return { isRoomAdmin, posts };
     } else {
       const [posts] = await pool.query(getPostDetailsByRoomId, [
         +roomId,

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -90,7 +90,6 @@ export const getAllPostInRoomDAO = async (roomId, userId, cursorId, size) => {
     }
 
     const isRoomAdmin = userId === room[0].admin_id;
-    console.log(isRoomAdmin);
 
     if (cursorId == "undefined" || typeof cursorId == "undefined" || cursorId == null) {
       const [posts] = await pool.query(getPostDetailsByRoomIdAtFirst, [+roomId, +userId, +size]);

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -11,7 +11,7 @@ export const allPostInRoomDTO = ({ isRoomAdmin, posts }) => {
     submitState: formatSubmitState(post.submit_state),
   }));
 
-  return { isRoomAdmin, post: returnPosts, cursorId: posts[posts.length - 1].id };
+  return { isRoomAdmin, posts: returnPosts, cursorId: posts[posts.length - 1].id };
 };
 
 const formatSubmitState = (data) => {

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -1,20 +1,17 @@
-export const allPostInRoomDTO = (data) => {
-  const posts = [];
+export const allPostInRoomDTO = ({ isRoomAdmin, posts }) => {
+  const returnPosts = posts.map((post) => ({
+    postId: post.id,
+    postType: post.type,
+    postTitle: post.title,
+    postBody: post.content,
+    postImage: post.URL,
+    startDate: formatDate(post.start_date),
+    endDate: formatDate(post.end_date),
+    commentCount: post.comment_count,
+    submitState: formatSubmitState(post.submit_state),
+  }));
 
-  for (let i = 0; i < data.length; i++) {
-    posts.push({
-      postId: data[i].id,
-      postType: data[i].type,
-      postTitle: data[i].title,
-      postBody: data[i].content,
-      postImage: data[i].URL,
-      startDate: formatDate(data[i].start_date),
-      endDate: formatDate(data[i].end_date),
-      commentCount: data[i].comment_count,
-      submitState: formatSubmitState(data[i].submit_state),
-    });
-  }
-  return { data: posts, cursorId: data[data.length - 1].id };
+  return { isRoomAdmin, post: returnPosts, cursorId: posts[posts.length - 1].id };
 };
 
 const formatSubmitState = (data) => {
@@ -93,6 +90,7 @@ export const allCommentsInPostDTO = (data, userId) => {
     commentId: comment.id,
     isCommentMine: isCommentMine(userId, comment.user_id),
     commentAuthorNickname: comment.nickname,
+    commentAuthorProfileImage: comment.profile_image,
     commentBody: comment.content,
     createdAt: formatDate(comment.created_at),
   }));

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -80,7 +80,7 @@ export const getPostImagesByPostId = `
 
 //공지글별 댓글 조회 (커서 없는 초기값)
 export const getCommentsByPostIdAtFirst = `
-  SELECT c.id, c.user_id, ur.nickname, c.content, c.created_at FROM comment c
+  SELECT c.id, c.user_id, ur.nickname, ur.profile_image, c.content, c.created_at FROM comment c
   JOIN post p ON p.id = ? AND c.post_id = p.id
   LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id AND p.room_id = ur.room_id
   WHERE c.state = 'EXIST'
@@ -89,7 +89,7 @@ export const getCommentsByPostIdAtFirst = `
 
 //공지글별 댓글 조회 (커서 존재)
 export const getCommentsByPostId = `
-  SELECT c.id, c.user_id, ur.nickname, c.content, c.created_at FROM comment c
+  SELECT c.id, c.user_id, ur.nickname, ur.profile_image, c.content, c.created_at FROM comment c
   JOIN post p ON p.id = ? AND c.post_id = p.id
   LEFT JOIN \`user-room\` ur ON c.user_id = ur.user_id AND p.room_id = ur.room_id
   WHERE c.state = 'EXIST' AND c.id > ?

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -103,7 +103,8 @@ paths:
                   result:
                     type: array
                     example: {
-                      "postData": [
+                      "isRoomAdmin": true,
+                      "post": [
                         {
                           "postId": 3,
                           "postType": "Quiz",
@@ -311,6 +312,7 @@ paths:
                           "commentId": 1,
                           "isCommentMine": false,
                           "commentAuthorNickname": "kimroom1",
+                          "commentAuthorProfileImage": null,
                           "commentBody": "com.con.1",
                           "createdAt": "24. 7. 27. 18:08",
                         },
@@ -318,6 +320,7 @@ paths:
                           "commentId": 3,
                           "isCommentMine": false,
                           "commentAuthorNickname": "parkroom1",
+                          "commentAuthorProfileImage": "parkroom1image.com",
                           "commentBody": "com.con.3",
                           "createdAt": "24. 7. 27. 18:09",
                         },
@@ -325,6 +328,7 @@ paths:
                           "commentId": 4,
                           "isCommentMine": true,
                           "commentAuthorNickname": "leeroom1",
+                          "commentAuthorProfileImage": "leeroom1image.com",
                           "commentBody": "com.con.4",
                           "createdAt": "24. 7. 27. 18:09",
                         },
@@ -332,6 +336,7 @@ paths:
                           "commentId": 5,
                           "isCommentMine": false,
                           "commentAuthorNickname": null,
+                          "commentAuthorProfileImage": null,
                           "commentBody": "com.con.5",
                           "createdAt": "24. 7. 27. 18:10",
                         },
@@ -339,6 +344,7 @@ paths:
                           "commentId": 7,
                           "isCommentMine": true,
                           "commentAuthorNickname": "leeroom1",
+                          "commentAuthorProfileImage": "leeroom1image.com",
                           "commentBody": "com.con.7",
                           "createdAt": "24. 7. 27. 18:11",
                         },
@@ -346,6 +352,7 @@ paths:
                           "commentId": 11,
                           "isCommentMine": false,
                           "commentAuthorNickname": "parkroom1",
+                          "commentAuthorProfileImage": "parkroom1image.com",
                           "commentBody": "testcontent",
                           "createdAt": "24. 8. 1. 16:22",
                         },
@@ -353,6 +360,7 @@ paths:
                           "commentId": 12,
                           "isCommentMine": false,
                           "commentAuthorNickname": "parkroom1",
+                          "commentAuthorProfileImage": "parkroom1image.com",
                           "commentBody": "testcontent",
                           "createdAt": "24. 8. 1. 16:22",
                         }

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -104,7 +104,7 @@ paths:
                     type: array
                     example: {
                       "isRoomAdmin": true,
-                      "post": [
+                      "posts": [
                         {
                           "postId": 3,
                           "postType": "Quiz",


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 각종 조회시 리턴값 추가 #154 

닫을 이슈 번호: resolved #154 

## 📌 반영 브랜치

> fix/#154 -> dev

## 📋 내용

> 공지방 내 전체 공지글 조회시 접속한 유저가 공지방 관리자인지 여부 리턴 추가 (isRoomAdmin: true/false) -> DAO, DTO, Swagger 예시 수정
> 댓글 조회시 해당 공지방에서의 유저별 프로필 사진 리턴 추가 ("commentAuthorProfileImage": "example.com") -> DTO, SQL, Swagger 예시 수정

### 🖼️ 스크린샷 (선택)

> ![image](https://github.com/user-attachments/assets/16ed0554-f4e5-4880-8623-bf2fd0a8c205)
> ![image](https://github.com/user-attachments/assets/d357a48f-b041-40d6-a03c-8905c4a4b4e2)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
