### PR TITLE
[refactor] 최근 공지 조회 및 입장한/개설한 공지방 조회 총페이지 수 리턴 추가

### DIFF
--- a/domains/user/user.dao.js
+++ b/domains/user/user.dao.js
@@ -187,7 +187,7 @@ export const findCreateRoomByUserId = async (userId, page, pageSize) => {
     const isNext = offset + pageSize < count;
 
     conn.release();
-    return { rooms, isNext };
+    return { rooms, isNext, totalCount: count };
   } catch (error) {
     console.log("내가 생성한 공지방 찾기 에러", error);
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
@@ -205,7 +205,7 @@ export const findJoinRoomByUserId = async (userId, page, pageSize) => {
     const isNext = offset + pageSize < count;
 
     conn.release();
-    return { rooms, isNext };
+    return { rooms, isNext, totalCount: count };
   } catch (error) {
     console.log("내가 입장한 공지방 찾기 에러", error);
     throw new BaseError(status.INTERNAL_SERVER_ERROR);

--- a/domains/user/user.service.js
+++ b/domains/user/user.service.js
@@ -207,12 +207,6 @@ export const getMyCreateRoom = async (userId, page, pageSize) => {
 };
 
 export const getMyJoinRoom = async (userId, page, pageSize) => {
-  // const userData = await findUserById(userId);
-
-  // if (!userData) {
-  //   throw new Error("사용자를 찾을 수 없습니다.");
-  // }
-
   const { rooms, isNext } = await findJoinRoomByUserId(userId, page, pageSize);
 
   if (!rooms) {
@@ -249,6 +243,8 @@ export const getLatestPostsInAllRooms = async (userId, page, pageSize) => {
   const rooms = await findAllRooms(userId, page, pageSize);
   const totalCount = await getRoomsCount(userId);
 
+  const totalPages = Math.ceil(totalCount / pageSize);
+
   const recentPostsPromises = rooms.map(async (room) => {
     const recentPost = await findLatestPostInRoom(room.id);
 
@@ -268,7 +264,7 @@ export const getLatestPostsInAllRooms = async (userId, page, pageSize) => {
   const recentPostList = (await Promise.all(recentPostsPromises)).filter((post) => post !== null);
   const isNext = page * pageSize < totalCount;
 
-  return { recentPostList, isNext };
+  return { recentPostList, isNext, totalPages };
 };
 
 export const getSubmitList = async (roomId) => {

--- a/domains/user/user.service.js
+++ b/domains/user/user.service.js
@@ -182,17 +182,13 @@ export const getMyRoomProfiles = async (userId, page, pageSize) => {
 };
 
 export const getMyCreateRoom = async (userId, page, pageSize) => {
-  // const userData = await findUserById(userId);
-
-  // if (!userData) {
-  //   throw new Error("사용자를 찾을 수 없습니다.");
-  // }
-
-  const { rooms, isNext } = await findCreateRoomByUserId(userId, page, pageSize);
+  const { rooms, isNext, totalCount } = await findCreateRoomByUserId(userId, page, pageSize);
 
   if (!rooms) {
-    return { rooms: null, isNext: false };
+    return { rooms: null, isNext: false, totalPages: 0 };
   }
+
+  const totalPages = Math.ceil(totalCount / pageSize);
 
   const Myrooms = rooms.map((room) => ({
     id: room.room_id,
@@ -203,15 +199,17 @@ export const getMyCreateRoom = async (userId, page, pageSize) => {
     latestPostTime: getRelativeTime(room.latest_post_time),
   }));
 
-  return { rooms: Myrooms, isNext };
+  return { rooms: Myrooms, isNext, totalPages };
 };
 
 export const getMyJoinRoom = async (userId, page, pageSize) => {
-  const { rooms, isNext } = await findJoinRoomByUserId(userId, page, pageSize);
+  const { rooms, isNext, totalCount } = await findJoinRoomByUserId(userId, page, pageSize);
 
   if (!rooms) {
-    return { rooms: null, isNext: false };
+    return { rooms: null, isNext: false, totalPages: 0 };
   }
+
+  const totalPages = Math.ceil(totalCount / pageSize);
 
   const Myrooms = rooms.map(async (room) => {
     const submitCount = await findSubmitCountInRoom(room.room_id, userId);
@@ -230,7 +228,7 @@ export const getMyJoinRoom = async (userId, page, pageSize) => {
 
   const RoomDatas = await Promise.all(Myrooms);
 
-  return { rooms: RoomDatas, isNext };
+  return { rooms: RoomDatas, isNext, totalPages };
 };
 
 export const checkRoomDuplicateNickname = async (roomId, nickname) => {

--- a/swagger/user.swagger.yaml
+++ b/swagger/user.swagger.yaml
@@ -446,6 +446,9 @@ paths:
                       isNext:
                         type: boolean
                         description: 다음 페이지가 있는지 여부
+                      totalPages:
+                        type: number
+                        description: 총 페이지 수
 
   /user/create-room:
     get:
@@ -519,6 +522,9 @@ paths:
                       isNext:
                         type: boolean
                         description: 다음 페이지가 있는지 여부
+                      totalPages:
+                        type: number
+                        description: 총 페이지 수
                       
   /user/join-room:
     get:
@@ -601,6 +607,9 @@ paths:
                       isNext:
                         type: boolean
                         description: 다음 페이지가 있는지 여부
+                      totalPages:
+                        type: number
+                        description: 총 페이지 수
 
   /user/profile:
     get:


### PR DESCRIPTION
# 🚩 관련 이슈

> [refactor] 최근 공지 조회 및 입장한/개설한 공지방 조회 총페이지 수 리턴 추가 #164

닫을 이슈 번호: resolved #164

## 📌 반영 브랜치

> refactor/#164 -> dev

## 📋 내용

> 최근 공지 조회 및 입장한/개설한 공지방 조회 총페이지 수 리턴 추가

### 🖼️ 스크린샷 (선택)

> 최근 공지글 목록 조회
![스크린샷 2024-08-09 오후 9 30 20](https://github.com/user-attachments/assets/d3ac3c17-98ed-4fdf-87f2-f8de67d14ed1)
내가 개설한 공지방 조회
![스크린샷 2024-08-09 오후 9 30 47](https://github.com/user-attachments/assets/4b59f6ec-e72a-4c48-af00-71ba5e899851)
내가 입장한 공지방 조회
![스크린샷 2024-08-09 오후 9 31 27](https://github.com/user-attachments/assets/d22f83e4-6350-46dd-ba39-81dfdf21d940)

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 
