### PR TITLE
[fix] 각종 조회시 리턴값 수정

### DIFF
--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -93,10 +93,7 @@ export const getAllPostInRoomDAO = async (roomId, userId, cursorId, size) => {
 
     if (cursorId == "undefined" || typeof cursorId == "undefined" || cursorId == null) {
       const [posts] = await pool.query(getPostDetailsByRoomIdAtFirst, [+roomId, +userId, +size]);
-      if (posts.length == 0) {
-        conn.release();
-        return -2;
-      }
+
       conn.release();
       return { isRoomAdmin, posts };
     } else {
@@ -106,10 +103,7 @@ export const getAllPostInRoomDAO = async (roomId, userId, cursorId, size) => {
         +cursorId,
         +size,
       ]);
-      if (posts.length == 0) {
-        conn.release();
-        return -2;
-      }
+
       conn.release();
       return { isRoomAdmin, posts };
     }
@@ -130,10 +124,7 @@ export const getNotCheckedPostInRoomDAO = async (roomId, userId) => {
     }
 
     const [posts] = await pool.query(getMyNotCheckedPostInRoom, [roomId, userId]);
-    if (posts.length == 0) {
-      conn.release();
-      return -2;
-    }
+
     conn.release();
     return posts;
   } catch (err) {
@@ -172,18 +163,10 @@ export const getCommentsDAO = async (postId, cursorId, size) => {
 
     if (cursorId == "undefined" || typeof cursorId == "undefined" || cursorId == null) {
       const [comments] = await pool.query(getCommentsByPostIdAtFirst, [+postId, +size]);
-      if (comments.length == 0) {
-        conn.release();
-        return -2;
-      }
       conn.release();
       return comments;
     } else {
       const [comments] = await pool.query(getCommentsByPostId, [+postId, +cursorId, +size]);
-      if (comments.length == 0) {
-        conn.release();
-        return -2;
-      }
       conn.release();
       return comments;
     }

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -1,6 +1,6 @@
 export const allPostInRoomDTO = ({ isRoomAdmin, posts }) => {
   if (posts.length == 0) {
-    return { isRoomAdmin, posts };
+    return { isRoomAdmin, posts, cursorId: null };
   }
 
   const returnPosts = posts.map((post) => ({

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -1,4 +1,8 @@
 export const allPostInRoomDTO = ({ isRoomAdmin, posts }) => {
+  if (posts.length == 0) {
+    return { isRoomAdmin, posts };
+  }
+
   const returnPosts = posts.map((post) => ({
     postId: post.id,
     postType: post.type,
@@ -9,6 +13,7 @@ export const allPostInRoomDTO = ({ isRoomAdmin, posts }) => {
     endDate: formatDate(post.end_date),
     commentCount: post.comment_count,
     submitState: formatSubmitState(post.submit_state),
+    unreadCount: post.unread_count,
   }));
 
   return { isRoomAdmin, posts: returnPosts, cursorId: posts[posts.length - 1].id };
@@ -70,6 +75,7 @@ export const detailedPostDTO = (data) => {
     endDate: formatDate(result.end_date),
     commentCount: result.comment_count,
     submitState: formatSubmitState(result.submit_state),
+    unreadCount: result.unread_count,
   }));
 
   const imageURLs = data.postImages.map((result) => result.URL);
@@ -78,6 +84,10 @@ export const detailedPostDTO = (data) => {
 };
 
 export const allCommentsInPostDTO = (data, userId) => {
+  if (data.length == 0) {
+    return { data, cursorId: null };
+  }
+
   const isCommentMine = (myUserId, commentUserId) => {
     if (myUserId === commentUserId) {
       return true;

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -59,10 +59,6 @@ export const getAllPostInRoom = async (roomId, userId, query) => {
     throw new Error("공지방을 찾을 수 없습니다.");
   }
 
-  if (roomData == -2) {
-    return null;
-  }
-
   return allPostInRoomDTO(roomData);
 };
 
@@ -71,10 +67,6 @@ export const getNotCheckedPostInRoom = async (roomId, userId) => {
 
   if (roomData == -1) {
     throw new Error("공지방을 찾을 수 없습니다.");
-  }
-
-  if (roomData == -2) {
-    return null;
   }
 
   return notCheckedPostInRoomDTO(roomData);
@@ -91,16 +83,12 @@ export const getDetailedPostService = async (postId, userId) => {
 };
 
 export const getCommentsService = async (postId, userId, query) => {
-  const { commentId, size = 100 } = query;
+  const { commentId, size = 20 } = query;
 
   const postData = await getCommentsDAO(postId, commentId, size);
 
   if (postData == -1) {
     throw new Error("공지글을 찾을 수 없습니다.");
-  }
-
-  if (postData == -2) {
-    return null;
   }
 
   return allCommentsInPostDTO(postData, userId);

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -20,7 +20,7 @@ export const getCommentById = `
 
 //공지방 내 공지글 정보, 나의 제출상태 가져오기 (커서 존재)
 export const getPostDetailsByRoomId = `
-  SELECT p.id, p.type, p.title, p.content, pi.URL, p.start_date, p.end_date, p.comment_count, s.submit_state FROM post p
+  SELECT p.id, p.type, p.title, p.content, pi.URL, p.start_date, p.end_date, p.comment_count, s.submit_state, p.unread_count FROM post p
   JOIN user u ON p.room_id = ? AND u.id = ?
   LEFT JOIN submit s ON s.post_id = p.id AND s.user_id = u.id
   LEFT JOIN (
@@ -38,7 +38,7 @@ export const getPostDetailsByRoomId = `
 
 //공지방 내 공지글 정보, 나의 제출상태 가져오기 (커서 없는 초기값)
 export const getPostDetailsByRoomIdAtFirst = `
-  SELECT p.id, p.type, p.title, p.content, pi.URL, p.start_date, p.end_date, p.comment_count, s.submit_state FROM post p
+  SELECT p.id, p.type, p.title, p.content, pi.URL, p.start_date, p.end_date, p.comment_count, s.submit_state, p.unread_count FROM post p
   JOIN user u ON p.room_id = ? AND u.id = ?
   LEFT JOIN submit s ON s.post_id = p.id AND s.user_id = u.id
   LEFT JOIN (
@@ -66,7 +66,7 @@ export const getMyNotCheckedPostInRoom = `
 
 //개별 공지글 정보 가져오기
 export const getDetailedPostSQL = `
-  SELECT p.id, p.type, p.title, p.content, p.start_date, p.end_date, p.comment_count, s.submit_state FROM post p
+  SELECT p.id, p.type, p.title, p.content, p.start_date, p.end_date, p.comment_count, s.submit_state, p.unread_count FROM post p
   JOIN user u ON u.id = ?
   LEFT JOIN submit s ON s.post_id = p.id AND s.user_id = u.id
   WHERE p.id = ? AND p.state = 'EXIST'

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -115,6 +115,7 @@ paths:
                           "endDate": "24. 7. 27. 19:05",
                           "commentCount": 1,
                           "submitState": "NOT_COMPLETE",
+                          "unreadCount": 200,
                         },
                         {
                           "postId": 2,
@@ -126,6 +127,7 @@ paths:
                           "endDate": "24. 7. 27. 19:01",
                           "commentCount": 0,
                           "submitState": "NOT_COMPLETE",
+                          "unreadCount": 18,
                         },
                         {
                           "postId": 1,
@@ -137,6 +139,7 @@ paths:
                           "endDate": "24. 7. 25. 05:24",
                           "commentCount": 5,
                           "submitState": "COMPLETE",
+                          "unreadCount": 6,
                         }
                     ],
                     "cursorId": 1,
@@ -248,6 +251,7 @@ paths:
                             "endDate": "24. 7. 25. 05:24",
                             "commentCount": 5,
                             "submitState": "COMPLETE",
+                            "unreadCount": 183,
                         }
                       ],
                       "imageURLs": [


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 각종 조회시 리턴값 수정 #166 

닫을 이슈 번호: resolved #166 

## 📌 반영 브랜치

> fix/#166 -> dev

## 📋 내용

> 공지방 내 전체 공지글 조회, 개별 공지글 조회에서 unreadCount도 반환하도록 추가

> 공지방 내 전체 공지글 조회, 미확인 공지글 조회, 공지글 내 전체 댓글 조회에서 해당되는 공지글 또는 댓글이 존재하지 않을 경우 NULL 반환을 빈 배열 반환으로 수정, isRoomAdmin은 반환하도록 추가, cursorId는 null로 반환하도록 추가

> 공지글 내 전체 댓글 조회에서 한번에 조회하는 댓글 개수 기본값을 100개에서 20개로 조정

### 🖼️ 스크린샷 (선택)

> 전체 공지글 조회에 unreadCount 추가
![image](https://github.com/user-attachments/assets/d239b2dc-4aa9-4765-b38b-2d78b9dcc358)

> 전체 공지글 조회에서 해당 공지방에 공지글 없을 경우
![image](https://github.com/user-attachments/assets/71fa1b27-caaf-485d-8787-64d8b19dd247)

> 미확인 공지글 조회에서 해당하는 공지글 없을 경우
![image](https://github.com/user-attachments/assets/b28d49d4-027e-41a2-88ef-39ff4c9bf657)

> 전체 댓글 조회에서 해당 공지글에 댓글 없을 경우
![image](https://github.com/user-attachments/assets/df6eaee4-bc81-4d73-b1bc-047bb767a16e)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
