### PR TITLE
[fix] URL로 공지방 입장, 이미 입장된 공지방인지 여부 추가 등 수정

### DIFF
--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -161,11 +161,11 @@ export const postSubmit = async (req, res, next) => {
 
 export const getRoomEntrance = async (req, res, next) => {
   try {
-    const uuid = req.params.uuid;
+    const url = req.params.url;
     const userId = req.user.userId;
     console.log("최초 입장시 공지방 정보 조회");
 
-    const result = await getRoomEntranceService(uuid, userId);
+    const result = await getRoomEntranceService(url, userId);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -162,9 +162,10 @@ export const postSubmit = async (req, res, next) => {
 export const getRoomEntrance = async (req, res, next) => {
   try {
     const roomId = req.params.roomId;
+    const userId = req.user.userId;
     console.log("최초 입장시 공지방 정보 조회");
 
-    const result = await getRoomEntranceService(roomId);
+    const result = await getRoomEntranceService(roomId, userId);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -161,11 +161,11 @@ export const postSubmit = async (req, res, next) => {
 
 export const getRoomEntrance = async (req, res, next) => {
   try {
-    const roomId = req.params.roomId;
+    const uuid = req.params.uuid;
     const userId = req.user.userId;
     console.log("최초 입장시 공지방 정보 조회");
 
-    const result = await getRoomEntranceService(roomId, userId);
+    const result = await getRoomEntranceService(uuid, userId);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -24,7 +24,7 @@ import {
   postSubmitImageSQL,
   deletePreviousSubmitImageSQL,
   getSubmitIdByPostIdAndUserId,
-  getRoomEntranceInfoByRoomId,
+  getRoomEntranceInfoByUUID,
   checkUserRoomExistenceSQL,
   checkRoomPasswordSQL,
   createRoomEntranceSQL,
@@ -349,17 +349,20 @@ export const postSubmitDAO = async (postId, userId, content, imageURLs) => {
   }
 };
 
-export const getRoomEntranceDAO = async (roomId, userId) => {
+export const getRoomEntranceDAO = async (uuid, userId) => {
   try {
     const conn = await pool.getConnection();
 
-    const [roomInfo] = await conn.query(getRoomEntranceInfoByRoomId, roomId);
+    const [roomInfo] = await conn.query(getRoomEntranceInfoByUUID, uuid);
     if (roomInfo.length == 0) {
       conn.release();
       return -1;
     }
 
-    const [isAlreadyJoinedRoom] = await conn.query(checkUserRoomExistenceSQL, [userId, roomId]);
+    const [isAlreadyJoinedRoom] = await conn.query(checkUserRoomExistenceSQL, [
+      userId,
+      roomInfo[0].roomId,
+    ]);
     conn.release();
     return { isAlreadyJoinedRoom: !!isAlreadyJoinedRoom[0].userRoomExistence, ...roomInfo[0] };
   } catch (err) {

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -24,7 +24,7 @@ import {
   postSubmitImageSQL,
   deletePreviousSubmitImageSQL,
   getSubmitIdByPostIdAndUserId,
-  getRoomEntranceInfoByUUID,
+  getRoomEntranceInfoByURL,
   checkUserRoomExistenceSQL,
   checkRoomPasswordSQL,
   createRoomEntranceSQL,
@@ -349,11 +349,11 @@ export const postSubmitDAO = async (postId, userId, content, imageURLs) => {
   }
 };
 
-export const getRoomEntranceDAO = async (uuid, userId) => {
+export const getRoomEntranceDAO = async (url, userId) => {
   try {
     const conn = await pool.getConnection();
 
-    const [roomInfo] = await conn.query(getRoomEntranceInfoByUUID, uuid);
+    const [roomInfo] = await conn.query(getRoomEntranceInfoByURL, url);
     if (roomInfo.length == 0) {
       conn.release();
       return -1;

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -25,6 +25,7 @@ import {
   deletePreviousSubmitImageSQL,
   getSubmitIdByPostIdAndUserId,
   getRoomEntranceInfoByRoomId,
+  checkUserRoomExistenceSQL,
   checkRoomPasswordSQL,
   createRoomEntranceSQL,
 } from "./room.sql.js";
@@ -87,6 +88,12 @@ export const getAllPostInRoomDAO = async (roomId, userId, cursorId, size) => {
     if (room.length == 0) {
       conn.release();
       return -1;
+    }
+
+    const [checkJoinedRoom] = await conn.query(checkUserRoomExistenceSQL, [userId, roomId]);
+    if (checkJoinedRoom[0].userRoomExistence == 0) {
+      conn.release();
+      return -2;
     }
 
     const isRoomAdmin = userId === room[0].admin_id;
@@ -342,7 +349,7 @@ export const postSubmitDAO = async (postId, userId, content, imageURLs) => {
   }
 };
 
-export const getRoomEntranceDAO = async (roomId) => {
+export const getRoomEntranceDAO = async (roomId, userId) => {
   try {
     const conn = await pool.getConnection();
 
@@ -351,8 +358,10 @@ export const getRoomEntranceDAO = async (roomId) => {
       conn.release();
       return -1;
     }
+
+    const [isAlreadyJoinedRoom] = await conn.query(checkUserRoomExistenceSQL, [userId, roomId]);
     conn.release();
-    return roomInfo[0];
+    return { isAlreadyJoinedRoom: !!isAlreadyJoinedRoom[0].userRoomExistence, ...roomInfo[0] };
   } catch (err) {
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
   }

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -150,8 +150,8 @@ export const postSubmitService = async (postId, userId, content, imageURLs) => {
   return submitData;
 };
 
-export const getRoomEntranceService = async (roomId, userId) => {
-  const roomData = await getRoomEntranceDAO(roomId, userId);
+export const getRoomEntranceService = async (uuid, userId) => {
+  const roomData = await getRoomEntranceDAO(uuid, userId);
   if (roomData == -1) {
     throw new Error("공지방을 찾을 수 없습니다.");
   }

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -150,8 +150,8 @@ export const postSubmitService = async (postId, userId, content, imageURLs) => {
   return submitData;
 };
 
-export const getRoomEntranceService = async (uuid, userId) => {
-  const roomData = await getRoomEntranceDAO(uuid, userId);
+export const getRoomEntranceService = async (url, userId) => {
+  const roomData = await getRoomEntranceDAO(url, userId);
   if (roomData == -1) {
     throw new Error("공지방을 찾을 수 없습니다.");
   }

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -59,6 +59,10 @@ export const getAllPostInRoom = async (roomId, userId, query) => {
     throw new Error("공지방을 찾을 수 없습니다.");
   }
 
+  if (roomData == -2) {
+    throw new Error("입장되어있는 공지방이 아닙니다.");
+  }
+
   return allPostInRoomDTO(roomData);
 };
 
@@ -146,9 +150,8 @@ export const postSubmitService = async (postId, userId, content, imageURLs) => {
   return submitData;
 };
 
-export const getRoomEntranceService = async (roomId) => {
-  const roomData = await getRoomEntranceDAO(roomId);
-
+export const getRoomEntranceService = async (roomId, userId) => {
+  const roomData = await getRoomEntranceDAO(roomId, userId);
   if (roomData == -1) {
     throw new Error("공지방을 찾을 수 없습니다.");
   }

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -167,7 +167,7 @@ export const getSubmitIdByPostIdAndUserId = `
 `;
 
 //공지방 최초 입장시 공지방 정보 가져오기
-export const getRoomEntranceInfoByUUID = `
+export const getRoomEntranceInfoByURL = `
   SELECT id as roomId, room_name as roomName, room_image as roomImage, admin_nickname as adminNickname
   FROM room WHERE room_invite_url = ? AND state = 'EXIST'
 `;

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -167,8 +167,9 @@ export const getSubmitIdByPostIdAndUserId = `
 `;
 
 //공지방 최초 입장시 공지방 정보 가져오기
-export const getRoomEntranceInfoByRoomId = `
-  SELECT room_name, room_image, admin_nickname FROM room WHERE id = ? AND state = 'EXIST'
+export const getRoomEntranceInfoByUUID = `
+  SELECT id as roomId, room_name as roomName, room_image as roomImage, admin_nickname as adminNickname
+  FROM room WHERE room_invite_url = ? AND state = 'EXIST'
 `;
 
 //공지방에 유저가 입장되어있는지 여부 확인

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -171,6 +171,15 @@ export const getRoomEntranceInfoByRoomId = `
   SELECT room_name, room_image, admin_nickname FROM room WHERE id = ? AND state = 'EXIST'
 `;
 
+//공지방에 유저가 입장되어있는지 여부 확인
+export const checkUserRoomExistenceSQL = `
+  SELECT EXISTS (
+  SELECT user_id, room_id
+  FROM \`user-room\`
+  WHERE user_id = ? AND room_id = ? LIMIT 1
+  ) AS userRoomExistence
+`;
+
 //공지방 비밀번호가 일치하는지 여부 확인
 export const checkRoomPasswordSQL = `
   SELECT BINARY r.room_password = ? AS isValidResult FROM room r WHERE r.id = ?

--- a/routes/room.route.js
+++ b/routes/room.route.js
@@ -31,6 +31,6 @@ roomRouter.post("/post/:postId/comment", tokenAuth, expressAsyncHandler(postComm
 roomRouter.delete("/post/comment/:commentId", tokenAuth, expressAsyncHandler(deleteComment));
 roomRouter.get("/post/:postId/submit", tokenAuth, expressAsyncHandler(getSubmitRequirements));
 roomRouter.post("/post/:postId/submit", tokenAuth, expressAsyncHandler(postSubmit));
-roomRouter.get("/enter/:uuid", tokenAuth, expressAsyncHandler(getRoomEntrance));
+roomRouter.get("/enter/:url", tokenAuth, expressAsyncHandler(getRoomEntrance));
 roomRouter.post("/enter/:roomId", tokenAuth, expressAsyncHandler(postRoomEntrance));
 roomRouter.post("/:roomId/checkPassword", tokenAuth, expressAsyncHandler(checkPassword));

--- a/routes/room.route.js
+++ b/routes/room.route.js
@@ -31,6 +31,6 @@ roomRouter.post("/post/:postId/comment", tokenAuth, expressAsyncHandler(postComm
 roomRouter.delete("/post/comment/:commentId", tokenAuth, expressAsyncHandler(deleteComment));
 roomRouter.get("/post/:postId/submit", tokenAuth, expressAsyncHandler(getSubmitRequirements));
 roomRouter.post("/post/:postId/submit", tokenAuth, expressAsyncHandler(postSubmit));
-roomRouter.get("/enter/:roomId", tokenAuth, expressAsyncHandler(getRoomEntrance));
+roomRouter.get("/enter/:uuid", tokenAuth, expressAsyncHandler(getRoomEntrance));
 roomRouter.post("/enter/:roomId", tokenAuth, expressAsyncHandler(postRoomEntrance));
 roomRouter.post("/:roomId/checkPassword", tokenAuth, expressAsyncHandler(checkPassword));

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -566,7 +566,7 @@ paths:
                         type: string
                         description: 제출 상태 (퀴즈의 경우 정답 여부에 따라 COMPLETE / NOT_COMPLETE, 미션의 경우 PENDING)
 
-  /room/enter/{uuid}:
+  /room/enter/{url}:
     get:
       tags:
         - room
@@ -578,7 +578,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - name: uuid
+        - name: url
           in: path
           schema:
             type: string
@@ -618,7 +618,7 @@ paths:
                         adminNickname:
                           type: string
                           description: 해당 공지방 관리자 닉네임
-                          
+
   /room/enter/{roomId}:
     post:
       tags:

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -107,7 +107,7 @@ paths:
                       "posts": [
                         {
                           "postId": 3,
-                          "postType": "Quiz",
+                          "postType": "QUIZ",
                           "postTitle": "test3",
                           "postBody": "testcontent3",
                           "postImage": "url31.com",
@@ -119,7 +119,7 @@ paths:
                         },
                         {
                           "postId": 2,
-                          "postType": "Mission",
+                          "postType": "MISSION",
                           "postTitle": "test2",
                           "postBody": "testcontent2",
                           "postImage": null,
@@ -131,7 +131,7 @@ paths:
                         },
                         {
                           "postId": 1,
-                          "postType": "Quiz",
+                          "postType": "QUIZ",
                           "postTitle": "TEST",
                           "postBody": "TESTCONTENT",
                           "postImage": "url11.com",
@@ -244,7 +244,7 @@ paths:
                       "post": [
                         {
                             "postId": 1,
-                            "postType": "Quiz",
+                            "postType": "QUIZ",
                             "postTitle": "TEST",
                             "postBody": "TESTCONTENT",
                             "startDate": "24. 7. 25. 04:24",
@@ -603,6 +603,9 @@ paths:
                   result:
                     type: object
                     properties:
+                        isAlreadyJoinedRoom:
+                          type: boolean
+                          description: 해당 공지방에 이미 입장되어있는지 여부
                         room_name:
                           type: string
                           description: 해당 공지방 이름

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -566,7 +566,7 @@ paths:
                         type: string
                         description: 제출 상태 (퀴즈의 경우 정답 여부에 따라 COMPLETE / NOT_COMPLETE, 미션의 경우 PENDING)
 
-  /room/enter/{roomId}:
+  /room/enter/{uuid}:
     get:
       tags:
         - room
@@ -578,10 +578,10 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - name: roomId
+        - name: uuid
           in: path
           schema:
-            type: number
+            type: string
           required: true
       responses:
         "200":
@@ -606,15 +606,20 @@ paths:
                         isAlreadyJoinedRoom:
                           type: boolean
                           description: 해당 공지방에 이미 입장되어있는지 여부
-                        room_name:
+                        roomId:
+                          type: number
+                          description: 해당 공지방 ID
+                        roomName:
                           type: string
                           description: 해당 공지방 이름
-                        room_image:
+                        roomImage:
                           type: string
                           description: 해당 공지방 이미지 URL
-                        admin_nickname:
+                        adminNickname:
                           type: string
                           description: 해당 공지방 관리자 닉네임
+                          
+  /room/enter/{roomId}:
     post:
       tags:
         - room


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 공지방 최초 입장 정보 조회에서 이미 입장된 공지방인지 여부 추가 #178 

닫을 이슈 번호: resolved #178 

## 📌 반영 브랜치

> fix/#178 -> dev

## 📋 내용

> 공지방 최초 입장 정보 조회에서 이미 입장된 공지방인지 여부 추가

> 공지방 전체 공지글 조회 (공지방 메인 입장) 에서 입장된 공지방이 아닐 경우 에러 출력하도록 추가

> Swagger 예시에 공지글 타입 대문자로 반영되어있지 않은 오류 수정

> 공지방 최초 입장시 Path 파라미터로 URL 사용하도록 수정 및 룸 ID 반환 추가, 해당 API 반환데이터명 카멜케이스로 수정

### 🖼️ 스크린샷 (선택)

> 공지방 최초 입장 정보 조회 Postman 테스트 화면
![image](https://github.com/user-attachments/assets/6af74d90-6165-445f-aa5b-24a92554f48c)

> 공지방 전체 공지글 조회 (공지방 메인 입장) 에서 입장된 공지방이 아닐 경우 에러 출력
![image](https://github.com/user-attachments/assets/89fd3a4b-4038-424e-a067-522bee5c8d9c)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
