### PR TITLE
[feat] 공지방 내 검색 기능 구현

### DIFF
--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -15,6 +15,7 @@ import {
   getRoomEntranceService,
   checkPasswordService,
   postRoomEntranceService,
+  searchPostInRoomService,
 } from "./room.service.js";
 
 export const fixPost = async (req, res, next) => {
@@ -193,6 +194,19 @@ export const postRoomEntrance = async (req, res, next) => {
     console.log("공지방 입장 등록");
 
     const result = await postRoomEntranceService(roomId, userId, userNickname);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const searchPostInRoom = async (req, res, next) => {
+  try {
+    const roomId = req.params.roomId;
+    const userId = req.user.userId;
+    console.log("공지방 내 공지글 검색");
+
+    const result = await searchPostInRoomService(roomId, userId, req.query);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.dao.js
+++ b/domains/room/room.dao.js
@@ -427,7 +427,7 @@ export const searchPostInRoomDAO = async (roomId, userId, query, cursorId, size)
       return -2;
     }
 
-    if (cursorId == "undefined" || typeof cursorId == "undefined" || cursorId == null) {
+    if (!cursorId) {
       const [posts] = await pool.query(searchPostInRoomSQLAtFirst, [
         +roomId,
         +userId,

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -107,3 +107,24 @@ export const allCommentsInPostDTO = (data, userId) => {
 
   return { data: comments, cursorId: data[data.length - 1].id };
 };
+
+export const searchPostInRoomDTO = (posts) => {
+  if (posts.length == 0) {
+    return { posts, cursorId: null };
+  }
+
+  const returnPosts = posts.map((post) => ({
+    postId: post.id,
+    postType: post.type,
+    postTitle: post.title,
+    postBody: post.content,
+    postImage: post.URL,
+    startDate: formatDate(post.start_date),
+    endDate: formatDate(post.end_date),
+    commentCount: post.comment_count,
+    submitState: formatSubmitState(post.submit_state),
+    unreadCount: post.unread_count,
+  }));
+
+  return { posts: returnPosts, cursorId: posts[posts.length - 1].id };
+};

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -12,6 +12,7 @@ import {
   getRoomEntranceDAO,
   checkPasswordDAO,
   postRoomEntranceDAO,
+  searchPostInRoomDAO,
 } from "./room.dao.js";
 
 import {
@@ -19,6 +20,7 @@ import {
   notCheckedPostInRoomDTO,
   detailedPostDTO,
   allCommentsInPostDTO,
+  searchPostInRoomDTO,
 } from "./room.dto.js";
 
 export const postFix = async (postId, userId) => {
@@ -183,4 +185,20 @@ export const postRoomEntranceService = async (roomId, userId, userNickname) => {
   }
 
   return { isSuccess: userRoomData };
+};
+
+export const searchPostInRoomService = async (roomId, userId, query) => {
+  const { q, postId, size = 10 } = query;
+
+  const roomData = await searchPostInRoomDAO(roomId, userId, q, postId, size);
+
+  if (roomData == -1) {
+    throw new Error("공지방을 찾을 수 없습니다.");
+  }
+
+  if (roomData == -2) {
+    throw new Error("입장되어있는 공지방이 아닙니다.");
+  }
+
+  return searchPostInRoomDTO(roomData);
 };

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -190,3 +190,39 @@ export const checkRoomPasswordSQL = `
 export const createRoomEntranceSQL = `
   INSERT INTO \`user-room\` (user_id, room_id, nickname) VALUES (?, ?, ?)
 `;
+
+//공지방 내 공지글 제목, 내용 대상으로 검색 (커서 존재)
+export const searchPostInRoomSQL = `
+  SELECT p.id, p.type, p.title, p.content, pi.URL, p.start_date, p.end_date, p.comment_count, s.submit_state, p.unread_count FROM post p
+  JOIN user u ON p.room_id = ? AND u.id = ?
+  LEFT JOIN submit s ON s.post_id = p.id AND s.user_id = u.id
+  LEFT JOIN (
+    SELECT pi.post_id, pi.URL
+    FROM \`post-image\` pi
+    JOIN (
+      SELECT post_id, MIN(id) AS min_id
+      FROM \`post-image\`
+      GROUP BY post_id
+    ) min_pi ON pi.id = min_pi.min_id
+  ) pi ON pi.post_id = p.id
+  WHERE p.state = 'EXIST' AND p.id < ? AND (p.title LIKE ? OR p.content LIKE ?)
+  ORDER BY p.id DESC LIMIT ?
+`;
+
+//공지방 내 공지글 제목, 내용 대상으로 검색 (커서 없는 초기값)
+export const searchPostInRoomSQLAtFirst = `
+  SELECT p.id, p.type, p.title, p.content, pi.URL, p.start_date, p.end_date, p.comment_count, s.submit_state, p.unread_count FROM post p
+  JOIN user u ON p.room_id = ? AND u.id = ?
+  LEFT JOIN submit s ON s.post_id = p.id AND s.user_id = u.id
+  LEFT JOIN (
+    SELECT pi.post_id, pi.URL
+    FROM \`post-image\` pi
+    JOIN (
+      SELECT post_id, MIN(id) AS min_id
+      FROM \`post-image\`
+      GROUP BY post_id
+    ) min_pi ON pi.id = min_pi.min_id
+  ) pi ON pi.post_id = p.id
+  WHERE p.state = 'EXIST' AND (p.title LIKE ? OR p.content LIKE ?)
+  ORDER BY p.id DESC LIMIT ?
+`;

--- a/routes/room.route.js
+++ b/routes/room.route.js
@@ -15,6 +15,7 @@ import {
   getRoomEntrance,
   postRoomEntrance,
   checkPassword,
+  searchPostInRoom,
 } from "../domains/room/room.controller.js";
 
 import { tokenAuth } from "../middleware/token.auth.js";
@@ -34,3 +35,4 @@ roomRouter.post("/post/:postId/submit", tokenAuth, expressAsyncHandler(postSubmi
 roomRouter.get("/enter/:url", tokenAuth, expressAsyncHandler(getRoomEntrance));
 roomRouter.post("/enter/:roomId", tokenAuth, expressAsyncHandler(postRoomEntrance));
 roomRouter.post("/:roomId/checkPassword", tokenAuth, expressAsyncHandler(checkPassword));
+roomRouter.get("/:roomId/search", tokenAuth, expressAsyncHandler(searchPostInRoom));

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -722,3 +722,90 @@ paths:
                           type: boolean
                           example: true
                           description: 비밀번호 일치 여부
+
+  /room/{roomId}/search:
+    get:
+      tags:
+        - room
+      summary: 공지방 내 공지글 검색
+      description: 공지방 내 공지글들의 제목과 내용을 대상으로 검색색, 커서 페이지네이션
+      operationId: searchPostInRoom
+      consumes:
+        - application/json  
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: roomId
+          in: path
+          schema:
+            type: number
+          required: true
+        - name: q
+          in: query
+          required: false
+          schema:
+            properties:
+              q:
+                type: string
+        - name: postId
+          in: query
+          required: false
+          schema:
+            properties:
+              postId:
+                type: number
+        - name: size
+          in: query
+          required: false
+          schema:
+            properties:
+              size:
+                type: number
+      responses:
+        "200":
+          description: 공지글 검색 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: array
+                    example: {
+                      "posts": [
+                        {
+                          "postId": 22,
+                          "postType": "QUIZ",
+                          "postTitle": "test3apple",
+                          "postBody": "testcontent3",
+                          "postImage": "url31.com",
+                          "startDate": "24. 7. 27. 19:05",
+                          "endDate": "24. 7. 27. 19:05",
+                          "commentCount": 1,
+                          "submitState": "NOT_COMPLETE",
+                          "unreadCount": 200,
+                        },
+                        {
+                          "postId": 17,
+                          "postType": "MISSION",
+                          "postTitle": "TEST",
+                          "postBody": "TESTappleCONTENT",
+                          "postImage": "url11.com",
+                          "startDate": "24. 7. 25. 04:24",
+                          "endDate": "24. 7. 25. 05:24",
+                          "commentCount": 5,
+                          "submitState": "COMPLETE",
+                          "unreadCount": 6,
+                        }
+                    ],
+                    "cursorId": 17,
+                    }


### PR DESCRIPTION
# 🚩 관련 이슈

> [feat] 공지방 내 검색 기능 구현 #157 

닫을 이슈 번호: resolved #157

## 📌 반영 브랜치

> feat/#157 -> dev

## 📋 내용

> 공지방 내 공지글의 제목 또는 글 내용에 해당 키워드가 있을 경우 나타나는 검색 기능 구현

> 기본적으로 공지방 내 전체 공지글 조회와 유사하지만 공지방 운영진인지 반환하는 부분만 제외

### 🖼️ 스크린샷 (선택)

> "회장"으로 검색한 경우
![image](https://github.com/user-attachments/assets/313105b6-d22d-4f47-82d9-8213a7b41b30)
![image](https://github.com/user-attachments/assets/68e65848-7e4c-48c0-9996-f21483b9ef3e)

> "프로젝트 진행"으로 검색한 경우
![image](https://github.com/user-attachments/assets/6fe33cfc-6525-45c7-8d28-9c677f90fa0f)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
