### PR TITLE
[feat] 공지방 입장시 받은 페널티 확인창 구현

### DIFF
--- a/domains/room/room.controller.js
+++ b/domains/room/room.controller.js
@@ -16,6 +16,8 @@ import {
   checkPasswordService,
   postRoomEntranceService,
   searchPostInRoomService,
+  checkPenaltyInRoomService,
+  exiledFromRoomService,
 } from "./room.service.js";
 
 export const fixPost = async (req, res, next) => {
@@ -207,6 +209,32 @@ export const searchPostInRoom = async (req, res, next) => {
     console.log("공지방 내 공지글 검색");
 
     const result = await searchPostInRoomService(roomId, userId, req.query);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const checkPenaltyInRoom = async (req, res, next) => {
+  try {
+    const roomId = req.params.roomId;
+    const userId = req.user.userId;
+    console.log("부여된 페널티 확인");
+
+    const result = await checkPenaltyInRoomService(roomId, userId);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const exiledFromRoom = async (req, res, next) => {
+  try {
+    const roomId = req.params.roomId;
+    const userId = req.user.userId;
+    console.log("페널티 한도 도달로 공지방에서 추방");
+
+    const result = await exiledFromRoomService(roomId, userId);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -1,6 +1,12 @@
-export const allPostInRoomDTO = ({ isRoomAdmin, posts }) => {
+export const allPostInRoomDTO = ({
+  isRoomAdmin,
+  penaltyCount,
+  maxPenalty,
+  notCheckedPenalty,
+  posts,
+}) => {
   if (posts.length == 0) {
-    return { isRoomAdmin, posts, cursorId: null };
+    return { isRoomAdmin, penaltyCount, maxPenalty, notCheckedPenalty, posts, cursorId: null };
   }
 
   const returnPosts = posts.map((post) => ({
@@ -16,7 +22,14 @@ export const allPostInRoomDTO = ({ isRoomAdmin, posts }) => {
     unreadCount: post.unread_count,
   }));
 
-  return { isRoomAdmin, posts: returnPosts, cursorId: posts[posts.length - 1].id };
+  return {
+    isRoomAdmin,
+    penaltyCount,
+    maxPenalty,
+    notCheckedPenalty,
+    posts: returnPosts,
+    cursorId: posts[posts.length - 1].id,
+  };
 };
 
 const formatSubmitState = (data) => {

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -1,12 +1,23 @@
 export const allPostInRoomDTO = ({
+  roomName,
   isRoomAdmin,
+  joinedRoomAt,
   penaltyCount,
   maxPenalty,
   notCheckedPenalty,
   posts,
 }) => {
   if (posts.length == 0) {
-    return { isRoomAdmin, penaltyCount, maxPenalty, notCheckedPenalty, posts, cursorId: null };
+    return {
+      roomName,
+      isRoomAdmin,
+      joinedRoomAt: formatDate(joinedRoomAt),
+      penaltyCount,
+      maxPenalty,
+      notCheckedPenalty,
+      posts,
+      cursorId: null,
+    };
   }
 
   const returnPosts = posts.map((post) => ({
@@ -23,7 +34,9 @@ export const allPostInRoomDTO = ({
   }));
 
   return {
+    roomName,
     isRoomAdmin,
+    joinedRoomAt: formatDate(joinedRoomAt),
     penaltyCount,
     maxPenalty,
     notCheckedPenalty,

--- a/domains/room/room.service.js
+++ b/domains/room/room.service.js
@@ -13,6 +13,8 @@ import {
   checkPasswordDAO,
   postRoomEntranceDAO,
   searchPostInRoomDAO,
+  checkPenaltyInRoomDAO,
+  exiledFromRoomDAO,
 } from "./room.dao.js";
 
 import {
@@ -201,4 +203,24 @@ export const searchPostInRoomService = async (roomId, userId, query) => {
   }
 
   return searchPostInRoomDTO(roomData);
+};
+
+export const checkPenaltyInRoomService = async (roomId, userId) => {
+  const userRoomData = await checkPenaltyInRoomDAO(roomId, userId);
+
+  if (userRoomData == -1) {
+    throw new Error("공지방을 찾을 수 없습니다.");
+  }
+
+  return { isSuccess: userRoomData };
+};
+
+export const exiledFromRoomService = async (roomId, userId) => {
+  const userRoomData = await exiledFromRoomDAO(roomId, userId);
+
+  if (userRoomData == -1) {
+    throw new Error("잘못된 삭제 요청입니다.");
+  }
+
+  return { isSuccess: userRoomData };
 };

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -227,9 +227,9 @@ export const searchPostInRoomSQLAtFirst = `
   ORDER BY p.id DESC LIMIT ?
 `;
 
-//공지방 내 현재 페널티 카운트와 최대 페널티 한도 조회
-export const getMyPenaltyCountAndRoomMaxSQL = `
-  SELECT ur.penalty_count AS penaltyCount, r.max_penalty AS maxPenalty
+//공지방에 가입한 날짜, 공지방 내 현재 페널티 카운트와 최대 페널티 한도 조회
+export const getMyRoomJoinDatetimeAndPenaltyCountAndRoomMaxSQL = `
+  SELECT ur.created_at AS joinedRoomAt, ur.penalty_count AS penaltyCount, r.max_penalty AS maxPenalty
   FROM \`user-room\` ur
   JOIN room r ON r.id = ? AND r.id = ur.room_id
   WHERE ur.user_id = ?

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -226,3 +226,37 @@ export const searchPostInRoomSQLAtFirst = `
   WHERE p.state = 'EXIST' AND (p.title LIKE ? OR p.content LIKE ?)
   ORDER BY p.id DESC LIMIT ?
 `;
+
+//공지방 내 현재 페널티 카운트와 최대 페널티 한도 조회
+export const getMyPenaltyCountAndRoomMaxSQL = `
+  SELECT ur.penalty_count AS penaltyCount, r.max_penalty AS maxPenalty
+  FROM \`user-room\` ur
+  JOIN room r ON r.id = ? AND r.id = ur.room_id
+  WHERE ur.user_id = ?
+`;
+
+//공지방 내 미확인 페널티부여 포스트 조회
+export const notCheckedPenaltyInRoomSQL = `
+  SELECT p.id AS postId, p.title AS postTitle
+  FROM post p
+  JOIN submit s ON s.user_id = ? AND s.post_id = p.id AND s.penalty_state = true AND s.penalty_checked = false
+  JOIN room r ON r.id = ? AND r.id = p.room_id
+  WHERE p.state = 'EXIST'
+  ORDER BY p.id ASC
+`;
+
+//공지방 내 미확인 페널티부여 확인처리
+export const checkPenaltyInRoomSQL = `
+  UPDATE submit s
+  JOIN post p ON s.post_id = p.id AND p.state = 'EXIST'
+  JOIN room r ON r.id = ? AND r.id = p.room_id
+  SET s.penalty_checked = true
+  WHERE s.user_id = ? AND s.penalty_state = true
+`;
+
+//공지방 내 최대 페널티 한도 도달로 공지방에서 추방
+export const getExiledFromRoomSQL = `
+  DELETE ur FROM \`user-room\` ur
+  JOIN room r ON r.id = ? AND ur.room_id = r.id
+  WHERE ur.user_id = ? AND ur.penalty_count >= r.max_penalty
+`;

--- a/routes/room.route.js
+++ b/routes/room.route.js
@@ -16,6 +16,8 @@ import {
   postRoomEntrance,
   checkPassword,
   searchPostInRoom,
+  checkPenaltyInRoom,
+  exiledFromRoom,
 } from "../domains/room/room.controller.js";
 
 import { tokenAuth } from "../middleware/token.auth.js";
@@ -24,15 +26,24 @@ export const roomRouter = express.Router();
 
 roomRouter.patch("/fixPost", tokenAuth, expressAsyncHandler(fixPost));
 roomRouter.delete("/fixPost", tokenAuth, expressAsyncHandler(deleteFixPost));
+
 roomRouter.get("/:roomId/all", tokenAuth, expressAsyncHandler(getAllPost));
 roomRouter.get("/:roomId/notChecked", tokenAuth, expressAsyncHandler(getNotCheckedPost));
+
 roomRouter.get("/post/:postId", tokenAuth, expressAsyncHandler(getDetailedPost));
+
 roomRouter.get("/post/:postId/comment", tokenAuth, expressAsyncHandler(getComments));
 roomRouter.post("/post/:postId/comment", tokenAuth, expressAsyncHandler(postComment));
 roomRouter.delete("/post/comment/:commentId", tokenAuth, expressAsyncHandler(deleteComment));
+
 roomRouter.get("/post/:postId/submit", tokenAuth, expressAsyncHandler(getSubmitRequirements));
 roomRouter.post("/post/:postId/submit", tokenAuth, expressAsyncHandler(postSubmit));
+
 roomRouter.get("/enter/:url", tokenAuth, expressAsyncHandler(getRoomEntrance));
 roomRouter.post("/enter/:roomId", tokenAuth, expressAsyncHandler(postRoomEntrance));
 roomRouter.post("/:roomId/checkPassword", tokenAuth, expressAsyncHandler(checkPassword));
+
 roomRouter.get("/:roomId/search", tokenAuth, expressAsyncHandler(searchPostInRoom));
+
+roomRouter.patch("/:roomId/check-penalty", tokenAuth, expressAsyncHandler(checkPenaltyInRoom));
+roomRouter.delete("/:roomId/exiled", tokenAuth, expressAsyncHandler(exiledFromRoom));

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -104,6 +104,18 @@ paths:
                     type: array
                     example: {
                       "isRoomAdmin": true,
+                      "penaltyCount": 3,
+                      "maxPenalty": 5,
+                      "notCheckedPenalty": [
+                          {
+                              "postId": 3,
+                              "postTitle": "테스트 제목입니다.",
+                          },
+                          {
+                              "postId": 2,
+                              "postTitle": "테스트 제목입니다.",
+                          }
+                      ],
                       "posts": [
                         {
                           "postId": 3,
@@ -809,3 +821,87 @@ paths:
                     ],
                     "cursorId": 17,
                     }
+                  
+  /room/{roomId}/check-penalty:
+    patch:
+      tags:
+        - room
+      summary: 공지방 내 미확인 페널티 확인처리
+      description: 공지방 내 미확인 페널티 팝업에 나온 페널티 포스트들을 확인한 것으로 처리
+      operationId: checkPenaltyInRoom
+      consumes:
+        - application/json  
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: roomId
+          in: path
+          schema:
+            type: number
+          required: true
+      responses:
+        "200":
+          description: 공지방 내 페널티 확인 처리 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: object
+                    properties:
+                        isSuccess:
+                          type: boolean
+                          example: true
+                          description: 페널티 확인 처리 성공
+
+  /room/{roomId}/exiled:
+    delete:
+      tags:
+        - room
+      summary: 공지방 페널티 최대한도 도달하여 퇴장처리
+      description: 공지방 페널티 최대한도 도달하여 퇴장처리
+      operationId: exiledFromRoom
+      consumes:
+        - application/json  
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: roomId
+          in: path
+          schema:
+            type: number
+          required: true
+      responses:
+        "200":
+          description: 공지방 퇴장 처리 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: object
+                    properties:
+                        isSuccess:
+                          type: boolean
+                          example: true
+                          description: 공지방 퇴장 처리 성공

--- a/swagger/room.swagger.yaml
+++ b/swagger/room.swagger.yaml
@@ -103,7 +103,9 @@ paths:
                   result:
                     type: array
                     example: {
+                      "roomName": "UMC 6기 공지방"
                       "isRoomAdmin": true,
+                      "joinedRoomAt": "24. 06. 27. 08:05"
                       "penaltyCount": 3,
                       "maxPenalty": 5,
                       "notCheckedPenalty": [
@@ -123,8 +125,8 @@ paths:
                           "postTitle": "test3",
                           "postBody": "testcontent3",
                           "postImage": "url31.com",
-                          "startDate": "24. 7. 27. 19:05",
-                          "endDate": "24. 7. 27. 19:05",
+                          "startDate": "24. 07. 27. 19:05",
+                          "endDate": "24. 07. 27. 19:05",
                           "commentCount": 1,
                           "submitState": "NOT_COMPLETE",
                           "unreadCount": 200,
@@ -135,8 +137,8 @@ paths:
                           "postTitle": "test2",
                           "postBody": "testcontent2",
                           "postImage": null,
-                          "startDate": "24. 7. 27. 19:01",
-                          "endDate": "24. 7. 27. 19:01",
+                          "startDate": "24. 07. 27. 19:01",
+                          "endDate": "24. 07. 27. 19:01",
                           "commentCount": 0,
                           "submitState": "NOT_COMPLETE",
                           "unreadCount": 18,
@@ -147,8 +149,8 @@ paths:
                           "postTitle": "TEST",
                           "postBody": "TESTCONTENT",
                           "postImage": "url11.com",
-                          "startDate": "24. 7. 25. 04:24",
-                          "endDate": "24. 7. 25. 05:24",
+                          "startDate": "24. 07. 25. 04:24",
+                          "endDate": "24. 07. 25. 05:24",
                           "commentCount": 5,
                           "submitState": "COMPLETE",
                           "unreadCount": 6,


### PR DESCRIPTION
# 🚩 관련 이슈

> [feat] 공지방 입장시 받은 페널티 확인창 구현 #202 

닫을 이슈 번호: resolved #202 

## 📌 반영 브랜치

> feat/#202 -> dev

## 📋 내용

> 내 페널티 카운트, 공지방 페널티 최대한도, 미확인 페널티 게시물 항목 전체 공지글 조회 API에 리턴 추가

> 전체 공지글 조회가 커서 스크롤 페이징임을 고려하여 이후 조회시에는 미확인 페널티 게시물 빈 배열로 반환

> 공지방 내 미확인 페널티를 확인 상태로 전환하는 API 추가

> 페널티 최대한도에 도달했을 때 공지방 퇴장 버튼을 통해 공지방에서 나가는 API 추가

> 전체 공지글 조회 API에 공지방 이름, 공지방에 가입한 날짜 추가


### 🖼️ 스크린샷 (선택)

> 내 페널티 카운트, 공지방 페널티 최대한도, 미확인 페널티 게시물 항목 전체 공지글 조회 API에 리턴 추가
![image](https://github.com/user-attachments/assets/2fd2a650-e1f9-4c3b-bd58-af19c4831d4d)

> 전체 공지글 조회가 커서 스크롤 페이징임을 고려하여 이후 조회시에는 미확인 페널티 게시물 빈 배열로 반환
![image](https://github.com/user-attachments/assets/7f55de32-43bb-4f9f-a6a8-ace3e09a8dd6)

> 공지방 내 미확인 페널티를 확인 상태로 전환하는 API 추가
![image](https://github.com/user-attachments/assets/1088a092-112f-4ac3-9eb9-7f16f34bc4fb)

> 페널티 최대한도에 도달했을 때 공지방 퇴장 버튼을 통해 공지방에서 나가는 API 추가
![image](https://github.com/user-attachments/assets/2344b156-7e86-4da7-8366-ca7d3722c84c)

> 전체 공지글 조회 API에 공지방 이름, 공지방에 가입한 날짜 추가! (24.08.18)
![image](https://github.com/user-attachments/assets/323932da-c659-4fa7-8a58-43143423601b)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
