### PR TITLE
[fix] 공지글 미확인한 사람 수 카운트 로직 변경 등

### DIFF
--- a/domains/admin/admin.controller.js
+++ b/domains/admin/admin.controller.js
@@ -140,7 +140,7 @@ export const userSubmitController = async (req, res, next) => {
 
 export const userRequestController = async (req, res, next) => {
   try {
-    const result = await userRequestService(req.body);
+    const result = await userRequestService(req.params.submitId, req.body);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -31,6 +31,7 @@ import {
   userRequestRejectSQL,
   getRoomSQL,
   getAlluserRoomSQL,
+  decreaseUnreadCountOneBySubmitId,
 } from "./admin.sql.js";
 
 import { updateUnreadCountByRoom } from "../room/room.sql.js";
@@ -413,12 +414,13 @@ export const userSubmitDao = async (roomId) => {
   }
 };
 
-export const userRequestDao = async (body) => {
+export const userRequestDao = async (submitId, body) => {
+  const conn = await pool.getConnection();
   try {
-    const conn = await pool.getConnection();
-
-    if (body.type === "accept") await conn.query(userRequestAcceptSQL, body.roomId);
-    else if (body.type === "reject") await conn.query(userRequestRejectSQL, body.roomId);
+    if (body.type === "accept") {
+      await conn.query(userRequestAcceptSQL, submitId);
+      await conn.query(decreaseUnreadCountOneBySubmitId, submitId);
+    } else if (body.type === "reject") await conn.query(userRequestRejectSQL, submitId);
     else throw new Error("유효하지 않은 type입니다.");
 
     conn.release();

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -33,6 +33,8 @@ import {
   getAlluserRoomSQL,
 } from "./admin.sql.js";
 
+import { updateUnreadCountByRoom } from "../room/room.sql.js";
+
 import schedule from "node-schedule";
 
 export const createRoomsDao = async (body, userId, roomInviteUrl) => {
@@ -304,6 +306,7 @@ export const deleteUserDao = async (body) => {
       return -1;
     }
     await conn.query(deleteUserSQL, [body.nickname, body.room_id]);
+    await conn.query(updateUnreadCountByRoom, body.room.id);
 
     conn.release();
     return "유저 강퇴에 성공하였습니다.";

--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -202,12 +202,11 @@ export const userSubmitService = async (roomId) => {
   }
 };
 
-export const userRequestService = async (body) => {
+export const userRequestService = async (submitId, body) => {
   try {
     const validTypes = ["accept", "reject"];
     if (!validTypes.includes(body.type)) throw new Error("올바른 type을 입력하세요.");
-    if (!body.roomId) throw new Error("요청을 수행하기를 위한 roomId가 필요합니다.");
-    return await userRequestDao(body);
+    return await userRequestDao(submitId, body);
   } catch (error) {
     throw error;
   }

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -77,8 +77,9 @@ export const unreadUserListSQL = `
 SELECT ur.profile_image, ur.nickname
 FROM \`user-room\` ur
 JOIN post p ON p.room_id = ur.room_id AND p.id = ?
+JOIN submit s ON s.post_id = p.id and s.user_id = ur.user_id
 WHERE ur.user_id NOT IN
-      (SELECT s.user_id FROM submit s WHERE s.submit_state = 'COMPLETE' AND s.post_id = p.id);
+      (SELECT s2.user_id FROM submit s2 WHERE s2.submit_state = 'COMPLETE' AND s2.post_id = p.id);
 `;
 
 // 유저 검색
@@ -241,3 +242,25 @@ export const userRequestRejectSQL = `
     WHERE p.room_id = ?
   );
 `;
+
+/*export const updateUnreadCountByPost = `
+  UPDATE post p2
+  SET unread_count =
+  (SELECT * FROM (SELECT COUNT(ur.user_id) AS unreadCount
+    FROM \`user-room\` ur
+    JOIN post p ON p.id = p2.id AND p.room_id = ur.room_id
+    JOIN submit s ON s.post_id = p.id and s.user_id = ur.user_id
+    WHERE ur.user_id NOT IN
+      (SELECT s2.user_id FROM submit s2 WHERE s2.submit_state = 'COMPLETE' AND s2.post_id = p.id)) AS tableA)
+  WHERE p2.id = ?
+`;
+
+export const getUnreadCountByPost = `
+  SELECT COUNT(ur.user_id)
+  FROM \`user-room\` ur
+  JOIN post p ON p.room_id = ur.room_id AND p.id = ?
+  JOIN submit s ON s.post_id = p.id and s.user_id = ur.user_id
+  WHERE ur.user_id NOT IN
+    (SELECT s2.user_id FROM submit s2 WHERE s2.submit_state = 'COMPLETE' AND s2.post_id = p.id)
+`;
+*/

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -226,21 +226,20 @@ export const getSubmitStateSQL = `
 export const userRequestAcceptSQL = `
   UPDATE submit
   SET submit_state = 'COMPLETE'
-  WHERE submit_state = 'PENDING' AND post_id IN (
-    SELECT p.id
-    FROM post p
-    WHERE p.room_id = ?
-  );
+  WHERE id = ? AND submit_state = 'PENDING'
 `;
 
 export const userRequestRejectSQL = ` 
   UPDATE submit
   SET submit_state = 'REJECT'
-  WHERE submit_state = 'PENDING' AND post_id IN (
-    SELECT p.id
-    FROM post p
-    WHERE p.room_id = ?
-  );
+  WHERE id = ? AND submit_state = 'PENDING'
+`;
+
+export const decreaseUnreadCountOneBySubmitId = `
+  UPDATE post p
+  JOIN submit s ON s.id = ?
+  SET p.unread_count = p.unread_count - 1
+  WHERE p.id = s.post_id
 `;
 
 /*export const updateUnreadCountByPost = `

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -241,25 +241,3 @@ export const decreaseUnreadCountOneBySubmitId = `
   SET p.unread_count = p.unread_count - 1
   WHERE p.id = s.post_id
 `;
-
-/*export const updateUnreadCountByPost = `
-  UPDATE post p2
-  SET unread_count =
-  (SELECT * FROM (SELECT COUNT(ur.user_id) AS unreadCount
-    FROM \`user-room\` ur
-    JOIN post p ON p.id = p2.id AND p.room_id = ur.room_id
-    JOIN submit s ON s.post_id = p.id and s.user_id = ur.user_id
-    WHERE ur.user_id NOT IN
-      (SELECT s2.user_id FROM submit s2 WHERE s2.submit_state = 'COMPLETE' AND s2.post_id = p.id)) AS tableA)
-  WHERE p2.id = ?
-`;
-
-export const getUnreadCountByPost = `
-  SELECT COUNT(ur.user_id)
-  FROM \`user-room\` ur
-  JOIN post p ON p.room_id = ur.room_id AND p.id = ?
-  JOIN submit s ON s.post_id = p.id and s.user_id = ur.user_id
-  WHERE ur.user_id NOT IN
-    (SELECT s2.user_id FROM submit s2 WHERE s2.submit_state = 'COMPLETE' AND s2.post_id = p.id)
-`;
-*/

--- a/domains/room/room.dto.js
+++ b/domains/room/room.dto.js
@@ -109,7 +109,13 @@ export const detailedPostDTO = (data) => {
 
   const imageURLs = data.postImages.map((result) => result.URL);
 
-  return { post, imageURLs };
+  return {
+    roomName: data.roomName,
+    isRoomAdmin: data.isRoomAdmin,
+    joinedRoomAt: formatDate(data.joinedRoomAt),
+    post,
+    imageURLs,
+  };
 };
 
 export const allCommentsInPostDTO = (data, userId) => {

--- a/domains/room/room.sql.js
+++ b/domains/room/room.sql.js
@@ -288,3 +288,10 @@ export const updateUnreadCountByRoom = `
   SET unread_count = tableA.unreadCount
   WHERE p3.id = tableA.id
 `;
+
+export const getRoomInfoAndUserRoomInfoByUserIdAndPostId = `
+  SELECT r.room_name, r.admin_id, ur.created_at
+  FROM room r 
+  JOIN \`user-room\` ur ON r.id = ur.room_id AND ur.user_id = ?
+  JOIN post p ON p.id = ? AND p.room_id = r.id
+`;

--- a/routes/admin.route.js
+++ b/routes/admin.route.js
@@ -33,4 +33,4 @@ adminRouter.get("/profile", tokenAuth, expressAsyncHandler(userProfileController
 adminRouter.get("/invitation/:roomId", tokenAuth, expressAsyncHandler(userInviteController));
 adminRouter.delete("/user-ban", tokenAuth, expressAsyncHandler(deleteUserController));
 adminRouter.get("/submit/:roomId", tokenAuth, expressAsyncHandler(userSubmitController));
-adminRouter.patch("/submit/user-request", tokenAuth, expressAsyncHandler(userRequestController));
+adminRouter.patch("/submit/:submitId", tokenAuth, expressAsyncHandler(userRequestController));

--- a/swagger/admin.swagger.yaml
+++ b/swagger/admin.swagger.yaml
@@ -839,7 +839,7 @@ paths:
                             submit_state:
                               type: string
                               example: "COMPLETE"
-  /admin/submit/user-request:
+  /admin/submit/{submitId}:
     patch:
       tags:
         - admin
@@ -850,6 +850,12 @@ paths:
         - application/json
       security:
         - bearerAuth: []
+      parameters:
+        - name: submitId
+          in: path
+          schema:
+            type: integer
+          required: true
       requestBody:
         required: true
         content:
@@ -859,10 +865,8 @@ paths:
               properties:
                 type:
                   type: string
-                  description: 요청 수락/거절
-                roomId:
-                  type: integer
-                  description: 공지방 아이디
+                  example: accept
+                  description: 요청 수락/거절 (accpet/reject)
       responses:
         "200":
           description: 제출 요청 수행 성공!

--- a/swagger/admin.swagger.yaml
+++ b/swagger/admin.swagger.yaml
@@ -683,7 +683,7 @@ paths:
                         type: string
                         description: 관리자 닉네임
 
-  /admin/rooms/user-ban:
+  /admin/user-ban:
     delete:
       tags:
         - admin


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 공지글 미확인한 사람 수 카운트 로직 변경 등 #211 

닫을 이슈 번호: resolved #211 

## 📌 반영 브랜치

> fix/#211 -> dev

## 📋 내용

>  공지글 미확인한 사람 수 카운트 관련 로직 변경
>  : 공지방 입장시 startDate가 미래인 포스트에 대해서 Submit 초기화 생성, 해당 공지방에 대해 미확인수 카운트 업데이트
>  : 공지방 탈퇴시 해당 공지방에 대해 미확인수 카운트 업데이트
>  : 공지글 생성시, Quiz에서 Submit 성공시에는 기존 로직 유지
>  : 미확인수 카운트 업데이트 시에는 user-room 테이블을 기반으로 submit이 존재하면서 Complete가 아닌 항목들을 체크
>  : 공지글 미확인 유저 조회 API도 같은 로직으로 작동하도록 수정

>  공지글 상세조회에 공지방 이름, 공지방 관리자 여부, 본인의 공지방 가입날짜 리턴 추가

>  유저 강퇴 API Swagger URL 오류 수정

> Submit 수락/거절 기능 수정, Submit 수락시 해당 포스트에 unreadCount 1 감소

### 🖼️ 스크린샷 (선택)

> 공지방 입장시 해당 공지방의 포스트 73, 74, 75 중 startDate가 미래인 74, 75에 대해서만 Submit 초기화 생성
![image](https://github.com/user-attachments/assets/05b407b6-c6ac-43ac-b594-01192dcf5c9b)
![image](https://github.com/user-attachments/assets/a771616c-c96e-43b5-b63e-7e817a26692f)

> Submit 수락/거절
![image](https://github.com/user-attachments/assets/4afe7e5d-8b26-4edc-ac00-8a89a7a15dbf)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
