### PR TITLE
[refactor] 확인 요청 내역 공지글 목록 조회 및 공지글에 대한 확인 요청 내역 조회 구현

### DIFF
--- a/domains/admin/admin.controller.js
+++ b/domains/admin/admin.controller.js
@@ -13,9 +13,10 @@ import {
   userProfileService,
   userInviteService,
   deleteUserService,
-  userSubmitService,
+  getSubmitListService,
   userRequestService,
   getRoomsService,
+  getPostListService,
 } from "./admin.service.js";
 
 export const createRoomsController = async (req, res, next) => {
@@ -129,9 +130,25 @@ export const deleteUserController = async (req, res, next) => {
   }
 };
 
-export const userSubmitController = async (req, res, next) => {
+// 확인 요청 내역 공지글 목록 조회
+export const getPostListController = async (req, res, next) => {
   try {
-    const result = await userSubmitService(req.params.roomId);
+    const result = await getPostListService(req.params.roomId);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+// 하나의 공지글에 대한 확인 요청 내역 (대기 or 승인 완료) 조회
+export const getSubmitListController = async (req, res, next) => {
+  try {
+    const { roomId, postId } = req.params;
+    const { state } = req.query;
+
+    console.log(state);
+
+    const result = await getSubmitListService(roomId, postId, state);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/routes/admin.route.js
+++ b/routes/admin.route.js
@@ -13,9 +13,10 @@ import {
   userProfileController,
   userInviteController,
   deleteUserController,
-  userSubmitController,
   userRequestController,
   getRoomsController,
+  getPostListController,
+  getSubmitListController,
 } from "../domains/admin/admin.controller.js";
 
 export const adminRouter = express.Router();
@@ -32,5 +33,11 @@ adminRouter.get("/users", tokenAuth, expressAsyncHandler(userListController));
 adminRouter.get("/profile", tokenAuth, expressAsyncHandler(userProfileController));
 adminRouter.get("/invitation/:roomId", tokenAuth, expressAsyncHandler(userInviteController));
 adminRouter.delete("/user-ban", tokenAuth, expressAsyncHandler(deleteUserController));
-adminRouter.get("/submit/:roomId", tokenAuth, expressAsyncHandler(userSubmitController));
+
+// 확인 요청 내역 공지글 목록 조회
+adminRouter.get("/posts/:roomId", tokenAuth, expressAsyncHandler(getPostListController));
+
+// 하나의 공지글에 대한 확인 요청 내역 (대기 or 승인 완료) 조회
+adminRouter.get("/submit/:roomId/:postId", tokenAuth, expressAsyncHandler(getSubmitListController));
+
 adminRouter.patch("/submit/:submitId", tokenAuth, expressAsyncHandler(userRequestController));

--- a/swagger/admin.swagger.yaml
+++ b/swagger/admin.swagger.yaml
@@ -731,13 +731,13 @@ paths:
                         type: string
                         example: 유저 강퇴에 성공하였습니다.
 
-  /admin/submit/{roomId}:
+  /admin/posts/{roomId}:
     get:
       tags:
         - admin
-      summary: 확인 요청 내역 조회(대기 or 승인 완료)
-      description: 확인 요청 내역 조회
-      operationId: getSubmitList
+      summary: 확인 요청 내역 공지글 목록 조회
+      description: 확인 요청 내역 공지글 목록 조회
+      operationId: getSubmitPostList
       consumes:
         - application/json
       security:
@@ -750,7 +750,7 @@ paths:
           required: true
       responses:
         "200":
-          description: 확인 요청 내역 조회 성공!
+          description: 확인 요청 내역 공지글 목록 조회 성공!
           content:
             application/json:
               schema:
@@ -766,79 +766,97 @@ paths:
                     type: string
                     example: "success!"
                   result:
-                    type: object
-                    properties:
-                      UserSubmissions:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            id:
-                              type: number
-                              description: 제출 id
-                            title:
-                              type: string
-                              example: "test9"
-                            start_date:
-                              type: string
-                              format: date-time
-                              example: "2024-08-11"
-                            end_date:
-                              type: string
-                              format: date-time
-                              example: "2024-08-10"
-                            content:
-                              type: string
-                              example: "penaltytestcontent"
-                            room_image:
-                              type: string
-                              nullable: true
-                              example: null
-                            pending_count:
-                              type: integer
-                              example: 2
-                      pendingStates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            submit_id:
-                              type: number
-                              example: 제출id
-                            profile_image:
-                              type: string
-                              nullable: true
-                              example: null
-                            nickname:
-                              type: string
-                              example: "제이"
-                            URL:
-                              type: string
-                              example: "https://s3.ap-northeast-2.amazonaws.com/read.me-bucket/43dbd401a34c7be69c9be7b123a13e67_exampleimage.png"
-                            submit_state:
-                              type: string
-                              example: "PENDING"
-                      completeStates:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            submit_id:
-                              type: number
-                              example: 제출id
-                            profile_image:
-                              type: string
-                              nullable: true
-                              example: null
-                            nickname:
-                              type: string
-                              example: "제이"
-                            URL:
-                              type: string
-                              example: "https://s3.ap-northeast-2.amazonaws.com/read.me-bucket/45425843b018b4ac8d235ad195b35a54_exampleimage.png"
-                            submit_state:
-                              type: string
-                              example: "COMPLETE"
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        postId:
+                          type: number
+                          description: 해당 post의 ID 값
+                        title:
+                          type: string
+                          description: 공지글의 제목
+                        content:
+                          type: string
+                          description: 공지글의 내용
+                        startDate:
+                          type: string
+                          description: 공지글의 시작일
+                        endDate:
+                          type: string
+                          description: 공지글의 마감일
+                        image:
+                          type: string
+                          description: 공지글의 사진 (1장)
+                        pendingCount:
+                          type: number
+                          description: 해당 공지글의 제출 횟수
+
+  /admin/submit/{roomId}/{postId}:
+    get:
+      tags:
+        - admin
+      summary: 하나의 공지글에 대한 확인 요청 내역 (대기 or 승인 완료) 조회
+      description: 하나의 공지글에 대한 확인 요청 내역 (대기 or 승인 완료) 조회
+      operationId: getSubmitList
+      consumes:
+        - application/json
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: roomId
+          in: path
+          schema:
+            type: integer
+          required: true
+        - name: postId
+          in: path
+          schema:
+            type: integer
+          required: true
+      responses:
+        "200":
+          description: 하나의 공지글에 대한 확인 요청 내역 (대기 or 승인 완료) 조회 성공!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        submitId:
+                          type: number
+                          description: 해당 제출의 아이디 값
+                        profileImage:
+                          type: string
+                          description: 제출한 유저의 프로필 이미지
+                        nickname:
+                          type: array
+                          description: 제출한 유저의 닉네임
+                        images:
+                          type: array
+                          items:
+                            type: string
+                            description: 제출한 이미지 리스트
+                        content:
+                          type: string
+                          description: 제출한 추가사항
+                        submitState:
+                          type: string
+                          description: 제출 상태
+
   /admin/submit/{submitId}:
     patch:
       tags:


### PR DESCRIPTION
# 🚩 관련 이슈

> [refactor] 확인 요청 내역 조회(admin) API 분리 및 코드 수정 #220

닫을 이슈 번호: resolved #220

## 📌 반영 브랜치

> refactor/#220 -> dev

## 📋 내용

> 확인 요청 내역 공지글 목록 조회 및 공지글에 대한 확인 요청 내역 조회 구현

### 🖼️ 스크린샷 (선택)

> 
![스크린샷 2024-08-19 오후 9 53 47](https://github.com/user-attachments/assets/0b33d73c-3843-43ee-94d3-3a0cd8747e36)
![스크린샷 2024-08-19 오후 9 54 25](https://github.com/user-attachments/assets/78a97f1c-0c3a-4712-839c-b3f8e4a9ba40)
![스크린샷 2024-08-19 오후 9 54 00](https://github.com/user-attachments/assets/4a6ccd1c-1c18-4ddc-af0e-ef50f68c16f2)


## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 
