### PR TITLE
[feat] 공지글 상세 조회 API 구현

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -104,13 +104,13 @@ export const status = {
   NOT_MY_POST: {
     status: StatusCodes.BAD_REQUEST,
     isSuccess: false,
-    code: "COMMON012",
+    code: "POST001",
     message: "본인의 공지글에 대해서만 조회가 가능합니다.",
   },
   NOT_FOUND_POST: {
     status: StatusCodes.NOT_FOUND,
     isSuccess: false,
-    code: "COMMON013",
+    code: "POST002",
     message: "존재하지 않는 공지글 ID 입니다.",
   },
 };

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -101,4 +101,16 @@ export const status = {
     code: "COMMON011",
     message: "이미지를 삭제하는데 실패했습니다.",
   },
+  NOT_MY_POST: {
+    status: StatusCodes.BAD_REQUEST,
+    isSuccess: false,
+    code: "COMMON012",
+    message: "본인의 공지글에 대해서만 조회가 가능합니다.",
+  },
+  NOT_FOUND_POST: {
+    status: StatusCodes.NOT_FOUND,
+    isSuccess: false,
+    code: "COMMON013",
+    message: "존재하지 않는 공지글 ID 입니다.",
+  },
 };

--- a/domains/admin/admin.controller.js
+++ b/domains/admin/admin.controller.js
@@ -17,6 +17,7 @@ import {
   userRequestService,
   getRoomsService,
   getPostListService,
+  getPostService,
 } from "./admin.service.js";
 
 export const createRoomsController = async (req, res, next) => {
@@ -61,6 +62,20 @@ export const deleteRoomsController = async (req, res, next) => {
 export const createPostController = async (req, res, next) => {
   try {
     const result = await createPostService(req.body, req.user.userId);
+    res.status(200).json(response(status.SUCCESS, result));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getPostController = async (req, res, next) => {
+  try {
+    const result = await getPostService(req.params.postId, req.user.userId);
+    if (result === -1) {
+      return res.status(404).json(response(status.NOT_FOUND_POST));
+    } else if (result === -2) {
+      return res.status(400).json(response(status.NOT_MY_POST));
+    }
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -32,6 +32,7 @@ import {
   getRoomSQL,
   getAlluserRoomSQL,
   decreaseUnreadCountOneBySubmitId,
+  getPostSQL,
 } from "./admin.sql.js";
 
 import { updateUnreadCountByRoom } from "../room/room.sql.js";
@@ -57,8 +58,8 @@ export const createRoomsDao = async (body, userId, roomInviteUrl) => {
     await conn.query(userRoomSQL, [userId, roomId, body.admin_nickname]);
 
     conn.release();
-    return{
-      roomId: roomId,  
+    return {
+      roomId: roomId,
       roomImage: body.room_image,
       adminNickname: body.admin_nickname,
       roomName: body.room_name,
@@ -177,6 +178,21 @@ export const createPostDao = async (body, userId) => {
   } catch (error) {
     await conn.rollback(); // 오류 발생 시 롤백
     console.error("공지글 생성 에러:", error);
+    throw new BaseError(status.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const getPostDAO = async (postId, userId) => {
+  const conn = await pool.getConnection();
+  try {
+    const [post] = await conn.query(getPostSQL, postId);
+    if (!post.length) return -1;
+    if (post[0].admin_id !== userId) return -2;
+    conn.release();
+    return post[0];
+  } catch (error) {
+    conn.release();
+    console.error("admin 공지글 조회하기 에러:", error);
     throw new BaseError(status.INTERNAL_SERVER_ERROR);
   }
 };

--- a/domains/admin/admin.dto.js
+++ b/domains/admin/admin.dto.js
@@ -12,6 +12,17 @@ export const createPostDTO = (createPostData) => {
   };
 };
 
+export const getPostDTO = (postData) => ({
+  type: postData.type,
+  title: postData.title,
+  content: postData.content,
+  imgURLs: postData.imgURLs,
+  startDate: postData.start_date,
+  endDate: postData.end_date,
+  question: postData.question,
+  quizAnswer: postData.quiz_answer,
+});
+
 export const updatePostDTO = (updatePostData) => {
   return {
     ...updatePostData,

--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -19,6 +19,7 @@ import {
   getRoomsDao,
   getPostListDao,
   getSubmitListDao,
+  getPostDAO,
 } from "./admin.dao.js";
 import { createShortUUID } from "./uuid.js";
 import {
@@ -27,6 +28,7 @@ import {
   updatePostDTO,
   getRoomsDTO,
   postListDTO,
+  getPostDTO,
 } from "./admin.dto.js";
 
 export const createRoomsService = async (body, userId) => {
@@ -92,6 +94,19 @@ export const createPostService = async (body, userId) => {
     return createPostDTO(postData);
   } catch (error) {
     console.error("공지글 생성하기 에러:", error);
+    throw error;
+  }
+};
+
+export const getPostService = async (postId, userId) => {
+  try {
+    const postData = await getPostDAO(postId, userId);
+
+    if (typeof postData === "number") return postData;
+
+    return getPostDTO(postData);
+  } catch (error) {
+    console.error("공지글 수정하기 에러:", error);
     throw error;
   }
 };
@@ -183,7 +198,7 @@ export const userInviteService = async (roomId) => {
 
 export const deleteUserService = async (body) => {
   try {
-    if(!body.userId) throw new Error("강퇴할 User의 ID가 필요합니다.");
+    if (!body.userId) throw new Error("강퇴할 User의 ID가 필요합니다.");
     const result = await deleteUserDao(body);
     if (result == -1) throw new Error("공지방에 유저가 없습니다.");
     return result;

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -57,6 +57,15 @@ export const createPostImgSQL = `
   INSERT INTO \`post-image\` (URL, post_id) VALUES(?,?);  
 `;
 
+// admin 공지글 조회
+export const getPostSQL = ` 
+  SELECT p.title, p.content, p.type, p.start_date, p.end_date, p.question, p.quiz_answer, r.admin_id
+  FROM post p
+  JOIN room r
+  ON r.id = p.room_id
+  WHERE p.id = ?;  
+`;
+
 // 공지글 수정 & 이미지 삭제
 export const updatePostSQL = ` 
   UPDATE post

--- a/routes/admin.route.js
+++ b/routes/admin.route.js
@@ -17,6 +17,7 @@ import {
   getRoomsController,
   getPostListController,
   getSubmitListController,
+  getPostController,
 } from "../domains/admin/admin.controller.js";
 
 export const adminRouter = express.Router();
@@ -26,6 +27,7 @@ adminRouter.patch("/rooms/:roomId", tokenAuth, expressAsyncHandler(updateRoomsCo
 adminRouter.get("/rooms/:roomId", tokenAuth, expressAsyncHandler(getRoomsController));
 adminRouter.delete("/rooms/:roomId", tokenAuth, expressAsyncHandler(deleteRoomsController));
 adminRouter.post("/post", tokenAuth, expressAsyncHandler(createPostController));
+adminRouter.get("/post/:postId", tokenAuth, expressAsyncHandler(getPostController));
 adminRouter.patch("/post/:postId", tokenAuth, expressAsyncHandler(updatePostController));
 adminRouter.delete("/post/:postId", tokenAuth, expressAsyncHandler(deletePostController));
 adminRouter.get("/post/:postId/unread", tokenAuth, expressAsyncHandler(unreadUserListController));

--- a/swagger/admin.swagger.yaml
+++ b/swagger/admin.swagger.yaml
@@ -340,6 +340,98 @@ paths:
                         type: string
                         description: 퀴즈 답
   /admin/post/{postId}:
+    get:
+      tags:
+        - admin
+      summary: 공지글 상세 조회
+      description: 공지글 수정을 위한 상세 조회를 합니다.
+      operationId: getPost
+      consumes:
+        - application/json
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: postId
+          required: true
+          schema:
+            type: integer
+            example: 1
+            description: postId
+      responses:
+        "200":
+          description: 공지글 상세 조회 성공!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: integer
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+                  result:
+                    type: object
+                    properties:
+                      title:
+                        type: string
+                        description: 공지글 제목
+                      content:
+                        type: string
+                        description: 공지글 본문
+                      imgURLs:
+                        type: string
+                        description: 공지글 이미지
+                      startDate:
+                        type: string
+                        description: 시작 기한
+                      endDate:
+                        type: string
+                        description: 마감 기한
+                      question:
+                        type: string
+                        description: 퀴즈/미션 질문
+                      quizAnswer:
+                        type: string
+                        description: 퀴즈 정답
+        "400":
+          description: 공지글 상세 조회 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: "COMMON012"
+                  message:
+                    type: string
+                    example: "존재하지 않는 공지글 ID 입니다."
+        "404":
+          description: 공지글 상세 조회 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: "COMMON013"
+                  message:
+                    type: string
+                    example: "본인의 공지글에 대해서만 조회가 가능합니다."
+
     patch:
       tags:
         - admin

--- a/swagger/admin.swagger.yaml
+++ b/swagger/admin.swagger.yaml
@@ -409,7 +409,7 @@ paths:
                     example: false
                   code:
                     type: string
-                    example: "COMMON012"
+                    example: "POST001"
                   message:
                     type: string
                     example: "존재하지 않는 공지글 ID 입니다."
@@ -425,7 +425,7 @@ paths:
                     example: false
                   code:
                     type: string
-                    example: "COMMON013"
+                    example: "POST002"
                   message:
                     type: string
                     example: "본인의 공지글에 대해서만 조회가 가능합니다."
@@ -472,7 +472,7 @@ paths:
                       description: 퀴즈/미션 질문
                     quizAnswer:
                       type: string
-                      description: 퀴즈/미션 질문                      
+                      description: 퀴즈/미션 질문
                 addImgURLs:
                   type: array
                   items:
@@ -503,7 +503,7 @@ paths:
                   result:
                     type: object
                     properties:
-                      
+
     delete:
       tags:
         - admin

--- a/utils/kakao.js
+++ b/utils/kakao.js
@@ -20,7 +20,6 @@ export const getKakaoUser = async (token) => {
   const response = await fetch("https://kapi.kakao.com/v2/user/me", {
     method: "GET",
     headers: {
-      // Authorization: `Bearer ${token}`,
       Authorization: `Bearer ${token}`,
       "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
     },


### PR DESCRIPTION
# 🚩 관련 이슈

> [feat] 공지글 상세 조회 API 구현 #227 

닫을 이슈 번호: resolved #227

## 📌 반영 브랜치

> feat/#227 -> dev

## 📋 내용

> admin의 공지글 상세 조회 API 구현했습니다.

### 🖼️ 스크린샷 (선택)

> 공지글 상세 조회 성공

![스크린샷 2024-08-20 오전 3 21 05](https://github.com/user-attachments/assets/11095614-0606-4595-90eb-60bc2462d7a5)

> 내 공지글을 다른 유저가 조회한 경우

![스크린샷 2024-08-20 오전 3 20 44](https://github.com/user-attachments/assets/475fafa1-7cfc-41ac-94bf-55f95ec79933)

> 존재하지 않는 공지글 ID의 경우

![스크린샷 2024-08-20 오전 3 21 08](https://github.com/user-attachments/assets/c34456e6-73ce-4324-ad0c-49360e5ad75f)

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> ex) 더 좋은 로직이 있을까요?
