### PR TITLE
[fix] 공지글에 대한 확인 요청 내역 조회 시 DELETE 상태 이미지 리턴 제외

### DIFF
--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -183,7 +183,7 @@ export const userInviteService = async (roomId) => {
 
 export const deleteUserService = async (body) => {
   try {
-    if(!body.userId) throw new Error("강퇴할 User의 ID가 필요합니다.");
+    if (!body.userId) throw new Error("강퇴할 User의 ID가 필요합니다.");
     const result = await deleteUserDao(body);
     if (result == -1) throw new Error("공지방에 유저가 없습니다.");
     return result;
@@ -213,11 +213,13 @@ export const getPostListService = async (roomId) => {
 export const getSubmitListService = async (roomId, postId, state) => {
   try {
     if (!roomId || !postId) throw new Error("요청 내역 조회를 위한 roomId와 postId가 필요합니다.");
-    if (state !== "pending" && state !== "complete") {
+
+    const normalizedState = state.toLowerCase();
+    if (normalizedState !== "pending" && normalizedState !== "complete") {
       throw new Error("pending 혹은 complete 중 하나의 값으로 요청해야합니다.");
     }
 
-    const submitList = await getSubmitListDao(roomId, postId, state.toUpperCase());
+    const submitList = await getSubmitListDao(roomId, postId, normalizedState.toUpperCase());
 
     return submitList;
   } catch (error) {

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -220,7 +220,7 @@ export const getSubmitStateSQL = `
   JOIN submit s ON p.id = s.post_id
   JOIN user u ON s.user_id = u.id
   LEFT JOIN \`submit-image\` si ON s.id = si.submit_id
-  WHERE p.room_id = ? AND p.id = ? AND s.submit_state = ?
+  WHERE p.room_id = ? AND p.id = ? AND s.submit_state = ? AND si.state = 'EXIST'
   GROUP BY s.id;
 `;
 


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 공지글에 대한 확인 요청 내역 조회 시 DELETE 상태 이미지 리턴 제외 #236

닫을 이슈 번호: resolved #236

## 📌 반영 브랜치

> fix/#236 -> dev

## 📋 내용

>  공지글에 대한 확인 요청 내역 조회 시 DELETE 상태 이미지 리턴 제외
상태에 따른 조회 시 대소문자 구분하지 않도록 수정

### 🖼️ 스크린샷 (선택)

> 

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 
