### PR TITLE
[fix] 최근 공지글 목록 조회 시 공지방 ID 및 이름 리턴 누락 추가 및 이미지 중복 리턴 수정

### DIFF
--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -432,6 +432,8 @@ export const getSubmitListDao = async (roomId, postId, state) => {
 
     const [submitList] = await conn.query(getSubmitStateSQL, [roomId, postId, state]);
 
+    console.log(submitList);
+
     conn.release();
 
     return submitList.map((submit) => ({

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -224,12 +224,14 @@ export const userSubmitSQL = `
 
 // 하나의 공지글에 대한 확인 요청 내역 (대기 or 승인 완료) 조회
 export const getSubmitStateSQL = `
-  SELECT s.id AS submit_id, ur.profile_image, ur.nickname, GROUP_CONCAT(si.URL ORDER BY si.created_at SEPARATOR ',') AS images, s.content, s.submit_state
+  SELECT s.id AS submit_id, ur.profile_image, ur.nickname, 
+         GROUP_CONCAT(DISTINCT CASE WHEN si.state = 'EXIST' THEN si.URL END ORDER BY si.created_at ASC) AS images, 
+         s.content, s.submit_state
   FROM post p
   JOIN submit s ON p.id = s.post_id
   JOIN \`user-room\` ur ON s.user_id = ur.user_id
   LEFT JOIN \`submit-image\` si ON s.id = si.submit_id
-  WHERE p.room_id = ? AND p.id = ? AND s.submit_state = ? AND si.state = 'EXIST'
+  WHERE p.room_id = ? AND p.id = ? AND s.submit_state = ?
   GROUP BY s.id;
 `;
 

--- a/domains/user/user.service.js
+++ b/domains/user/user.service.js
@@ -258,8 +258,8 @@ export const getLatestPostsInAllRooms = async (userId, page, pageSize) => {
 
       return recentPost
         ? {
-            roomId: room.id,
-            roomName: room.room_name,
+            roomId: room.roomId,
+            roomName: room.roomName,
             postId: recentPost.post_id,
             title: recentPost.title,
             createdAt: getRelativeTime(recentPost.created_at),


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 최근 공지글 목록 조회 시 공지방 ID 및 이름 리턴 누락 추가 및 이미지 중복 리턴 수정 #243

닫을 이슈 번호: resolved #243

## 📌 반영 브랜치

> fix/#243 -> dev

## 📋 내용

> 최근 공지글 목록 조회 시 공지방 ID 및 이름 리턴 누락 추가
공지글 확인요청내역 조회 시 이미지 중복 리턴 수정

### 🖼️ 스크린샷 (선택)

> 

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 
