### PR TITLE
[fix] 마이페이지 공지방마다 제출한 미션 내역 조회 시 제출 이미지 EXIST 상태만 리턴하도록 수정

### DIFF
--- a/domains/user/user.sql.js
+++ b/domains/user/user.sql.js
@@ -180,7 +180,7 @@ export const getSubmitListInRoom = `
 export const getSubmitImages = `
   SELECT si.URL
   FROM \`submit-image\` si
-  WHERE si.submit_id = ?
+  WHERE si.submit_id = ? AND si.state = 'EXIST'
 `;
 
 // 해당 공지방에 대한 내 페널티 개수 및 최대 페널티 개수 구하기


### PR DESCRIPTION
# 🚩 관련 이슈

> [fix] 마이페이지 공지방마다 제출한 미션 내역 조회 시 제출 이미지 EXIST 상태만 리턴하도록 수정 #248

닫을 이슈 번호: resolved #248

## 📌 반영 브랜치

> fix/#248 -> dev

## 📋 내용

> 마이페이지 공지방마다 제출한 미션 내역 조회 시 제출 이미지 EXIST 상태만 리턴하도록 수정

### 🖼️ 스크린샷 (선택)

> 

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 
