### PR TITLE
[refactor] 내가 개설한 공지방 및 입장한 공지방 조회 시 시간순에 맞게 리턴하도록 수정

### DIFF
--- a/domains/user/user.dao.js
+++ b/domains/user/user.dao.js
@@ -231,10 +231,7 @@ export const findCreateRoomByUserId = async (userId, page, pageSize) => {
     const offset = (page - 1) * pageSize;
 
     const [[{ count }]] = await conn.query(getCreateRoomCount, [userId]);
-    console.log(count);
-
     const [rooms] = await conn.query(getCreateRoom, [userId, pageSize, offset]);
-    console.log(rooms);
 
     const isNext = offset + pageSize < count;
 

--- a/domains/user/user.dao.js
+++ b/domains/user/user.dao.js
@@ -231,7 +231,10 @@ export const findCreateRoomByUserId = async (userId, page, pageSize) => {
     const offset = (page - 1) * pageSize;
 
     const [[{ count }]] = await conn.query(getCreateRoomCount, [userId]);
+    console.log(count);
+
     const [rooms] = await conn.query(getCreateRoom, [userId, pageSize, offset]);
+    console.log(rooms);
 
     const isNext = offset + pageSize < count;
 

--- a/domains/user/user.sql.js
+++ b/domains/user/user.sql.js
@@ -118,6 +118,7 @@ export const getCreateRoom = `
   LEFT JOIN post ON r.id = post.room_id
   WHERE  r.admin_id = ?
   GROUP BY r.id
+  ORDER BY r.created_at DESC
   LIMIT ?
   OFFSET ?
 `;
@@ -139,6 +140,7 @@ export const getJoinRoom = `
   LEFT JOIN post ON room.id = post.room_id
   WHERE ur.user_id = ? AND room.admin_id <> ?
   GROUP BY room.id, ur.nickname
+  ORDER BY ur.created_at DESC
   LIMIT ?
   OFFSET ?
 `;


### PR DESCRIPTION
# 🚩 관련 이슈

> [refactor] 내가 개설한 공지방 및 입장한 공지방 조회 시 시간순에 맞게 리턴하도록 수정 #251

닫을 이슈 번호: resolved #251

## 📌 반영 브랜치

> refactor/#251 -> dev

## 📋 내용

>
- [ ] 내가 개설한 공지방 조회
  - [ ] 공지방이 개설된 시간 기준
- [ ] 내가 입장한 공지방 조회
  - [ ] 사용자가 공지방을 입장한 시간의 역순 (최신순)

### 🖼️ 스크린샷 (선택)

> 

## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요
>
> 