### PR TITLE
[refactor] 유저 검색 api 수정

### DIFF
--- a/domains/admin/admin.controller.js
+++ b/domains/admin/admin.controller.js
@@ -120,7 +120,7 @@ export const userListController = async (req, res, next) => {
 
 export const userProfileController = async (req, res, next) => {
   try {
-    const result = await userProfileService(req.params.roomId, req.user.userId);
+    const result = await userProfileService(req.query.roomId, req.query.userId);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/admin/admin.controller.js
+++ b/domains/admin/admin.controller.js
@@ -120,7 +120,7 @@ export const userListController = async (req, res, next) => {
 
 export const userProfileController = async (req, res, next) => {
   try {
-    const result = await userProfileService(req.query.roomId, req.query.userId);
+    const result = await userProfileService(req.params.roomId, req.user.userId);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/admin/admin.controller.js
+++ b/domains/admin/admin.controller.js
@@ -111,7 +111,7 @@ export const unreadUserListController = async (req, res, next) => {
 
 export const userListController = async (req, res, next) => {
   try {
-    const result = await userListService(req.query.nickname, req.query.roomId);
+    const result = await userListService(req.query.nickname, req.query.roomId, req.user.userId);
     res.status(200).json(response(status.SUCCESS, result));
   } catch (error) {
     next(error);

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -269,10 +269,10 @@ export const userListDao = async (nickname, roomId, userId) => {
     if (nickname && nickname.trim() !== "") {
       // nickname 유효성 검사
       userListSQLQuery = userListNameSQL;
-      params = [nickname, roomId];
+      params = [nickname, roomId, userId];
     } else {
       userListSQLQuery = userListSQL; // 모든 유저 조회 쿼리
-      params = [roomId];
+      params = [roomId, userId];
     }
     const [userData] = await conn.query(userListSQLQuery, params);
 

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -17,6 +17,7 @@ import {
   unreadUserListSQL,
   userListNameSQL,
   userListSQL,
+  adminProfileSQL,
   userProfileSQL,
   userInviteSQL,
   checkUserInRoomSQL,
@@ -285,9 +286,10 @@ export const userListDao = async (nickname, roomId) => {
 export const userProfileDao = async (roomId, userId) => {
   try {
     const conn = await pool.getConnection();
-    const [result] = await conn.query(userProfileSQL, [userId, roomId]);
+    const [adminData] = await conn.query(adminProfileSQL, [roomId, userId]); 
+    const [userData] = await conn.query(userProfileSQL, [roomId]);
     conn.release();
-    return result[0];
+    return {adminData, userData};
   } catch (error) {
     console.log("User 프로필 조회 에러");
     throw new BaseError(status.INTERNAL_SERVER_ERROR);

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -17,7 +17,6 @@ import {
   unreadUserListSQL,
   userListNameSQL,
   userListSQL,
-  adminProfileSQL,
   userProfileSQL,
   userInviteSQL,
   checkUserInRoomSQL,
@@ -286,10 +285,9 @@ export const userListDao = async (nickname, roomId) => {
 export const userProfileDao = async (roomId, userId) => {
   try {
     const conn = await pool.getConnection();
-    const [adminData] = await conn.query(adminProfileSQL, [roomId, userId]); 
-    const [userData] = await conn.query(userProfileSQL, [roomId]);
+    const [result] = await conn.query(userProfileSQL, [userId, roomId]);
     conn.release();
-    return {adminData, userData};
+    return result[0];
   } catch (error) {
     console.log("User 프로필 조회 에러");
     throw new BaseError(status.INTERNAL_SERVER_ERROR);

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -269,10 +269,10 @@ export const userListDao = async (nickname, roomId, userId) => {
     if (nickname && nickname.trim() !== "") {
       // nickname 유효성 검사
       userListSQLQuery = userListNameSQL;
-      params = [nickname, roomId, userId];
+      params = [nickname, roomId];
     } else {
       userListSQLQuery = userListSQL; // 모든 유저 조회 쿼리
-      params = [roomId, userId];
+      params = [roomId];
     }
     const [userData] = await conn.query(userListSQLQuery, params);
 

--- a/domains/admin/admin.dao.js
+++ b/domains/admin/admin.dao.js
@@ -15,6 +15,7 @@ import {
   deletePostImgSQL,
   deletePostSQL,
   unreadUserListSQL,
+  getAdminInfoSQL,
   userListNameSQL,
   userListSQL,
   userProfileSQL,
@@ -258,12 +259,13 @@ export const unreadUserListDao = async (postId) => {
   }
 };
 
-export const userListDao = async (nickname, roomId) => {
+export const userListDao = async (nickname, roomId, userId) => {
   try {
     const conn = await pool.getConnection();
-    let userListSQLQuery,
-      params = [];
 
+    const [adminData] = await conn.query(getAdminInfoSQL, [roomId, userId]); 
+
+    let userListSQLQuery, params = [];
     if (nickname && nickname.trim() !== "") {
       // nickname 유효성 검사
       userListSQLQuery = userListNameSQL;
@@ -272,10 +274,10 @@ export const userListDao = async (nickname, roomId) => {
       userListSQLQuery = userListSQL; // 모든 유저 조회 쿼리
       params = [roomId];
     }
+    const [userData] = await conn.query(userListSQLQuery, params);
 
-    const [result] = await conn.query(userListSQLQuery, params);
     conn.release();
-    return result;
+    return {adminData, userData};
   } catch (error) {
     console.log("User 검색 에러:", error);
     throw new BaseError(status.INTERNAL_SERVER_ERROR);

--- a/domains/admin/admin.dto.js
+++ b/domains/admin/admin.dto.js
@@ -77,9 +77,9 @@ export const postListDTO = (post) => ({
   pendingCount: parseInt(post.pending_count, 10) || 0,
 });
 
-export const userListDTO = (adminData, userData) => { 
+export const userListDTO = (adminData, userData, nickname) => { 
   return {
-    adminProfile: { 
+    adminProfile: nickname ? {} : { 
       nickname: adminData[0].nickname, 
       profileImage: adminData[0].profile_image 
     }, 

--- a/domains/admin/admin.dto.js
+++ b/domains/admin/admin.dto.js
@@ -76,3 +76,17 @@ export const postListDTO = (post) => ({
   image: post.images ? post.images.split(",")[0] : null,
   pendingCount: parseInt(post.pending_count, 10) || 0,
 });
+
+export const userListDTO = (adminData, userData) => { 
+  return {
+    adminProfile: { 
+      nickname: adminData[0].nickname, 
+      profileImage: adminData[0].profile_image 
+    }, 
+    userProfile: userData.map(row => ({
+      userId: row.user_id,
+      nickname: row.nickname, 
+      profileImage: row.profile_image 
+    }))
+  };
+}; 

--- a/domains/admin/admin.dto.js
+++ b/domains/admin/admin.dto.js
@@ -12,6 +12,20 @@ export const createPostDTO = (createPostData) => {
   };
 };
 
+export const profileDTO = (adminData, userData) => {
+  return {
+    adminProfile: adminData.map(row => ({ 
+      nickname: row.nickname, 
+      profileImage: row.profile_image 
+    })),
+    userProfile: userData.map(row => ({
+      userId: row.user_id,
+      nickname: row.nickname, 
+      profileImage: row.profile_image 
+    }))
+  };
+};
+
 export const getPostDTO = (postData) => ({
   type: postData.type,
   title: postData.title,
@@ -22,12 +36,6 @@ export const getPostDTO = (postData) => ({
   question: postData.question,
   quizAnswer: postData.quiz_answer,
 });
-
-export const updatePostDTO = (updatePostData) => {
-  return {
-    ...updatePostData,
-  };
-};
 
 export const getRoomsDTO = (roomData) => ({
   roomImage: roomData.room_image,

--- a/domains/admin/admin.dto.js
+++ b/domains/admin/admin.dto.js
@@ -14,10 +14,10 @@ export const createPostDTO = (createPostData) => {
 
 export const profileDTO = (adminData, userData) => {
   return {
-    adminProfile: adminData.map(row => ({ 
-      nickname: row.nickname, 
-      profileImage: row.profile_image 
-    })),
+    adminProfile: { 
+      nickname: adminData[0].nickname, 
+      profileImage: adminData[0].profile_image 
+    },
     userProfile: userData.map(row => ({
       userId: row.user_id,
       nickname: row.nickname, 

--- a/domains/admin/admin.dto.js
+++ b/domains/admin/admin.dto.js
@@ -12,20 +12,6 @@ export const createPostDTO = (createPostData) => {
   };
 };
 
-export const profileDTO = (adminData, userData) => {
-  return {
-    adminProfile: { 
-      nickname: adminData[0].nickname, 
-      profileImage: adminData[0].profile_image 
-    },
-    userProfile: userData.map(row => ({
-      userId: row.user_id,
-      nickname: row.nickname, 
-      profileImage: row.profile_image 
-    }))
-  };
-};
-
 export const getPostDTO = (postData) => ({
   type: postData.type,
   title: postData.title,

--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -26,7 +26,6 @@ import {
   createRoomsDTO,
   createPostDTO,
   getRoomsDTO,
-  profileDTO,
   postListDTO,
   getPostDTO,
 } from "./admin.dto.js";
@@ -172,10 +171,11 @@ export const userListService = async (nickname, roomId) => {
 
 export const userProfileService = async (roomId, userId) => {
   try {
-    if (!roomId) throw new Error("프로필 조회를 위한 공지방 ID가 필요합니다.");
-    
-    const {adminData, userData} = await userProfileDao(roomId, userId);
-    return profileDTO(adminData, userData) || [];
+    if (!roomId || !userId) {
+      throw new Error("공지방 혹은 사용자 ID가 필요합니다.");
+    }
+    const userProfileData = await userProfileDao(roomId, userId);
+    return userProfileData || [];
   } catch (error) {
     throw error;
   }

--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -26,6 +26,7 @@ import {
   createRoomsDTO,
   createPostDTO,
   getRoomsDTO,
+  profileDTO,
   postListDTO,
   getPostDTO,
 } from "./admin.dto.js";
@@ -171,11 +172,10 @@ export const userListService = async (nickname, roomId) => {
 
 export const userProfileService = async (roomId, userId) => {
   try {
-    if (!roomId || !userId) {
-      throw new Error("공지방 혹은 사용자 ID가 필요합니다.");
-    }
-    const userProfileData = await userProfileDao(roomId, userId);
-    return userProfileData || [];
+    if (!roomId) throw new Error("프로필 조회를 위한 공지방 ID가 필요합니다.");
+    
+    const {adminData, userData} = await userProfileDao(roomId, userId);
+    return profileDTO(adminData, userData) || [];
   } catch (error) {
     throw error;
   }

--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -27,6 +27,7 @@ import {
   createPostDTO,
   getRoomsDTO,
   postListDTO,
+  userListDTO,
   getPostDTO,
 } from "./admin.dto.js";
 
@@ -150,19 +151,13 @@ export const unreadUserListService = async (postId) => {
   }
 };
 
-export const userListService = async (nickname, roomId) => {
+export const userListService = async (nickname, roomId, userId) => {
   try {
-    if (!roomId) {
-      throw new Error("조회할 공지방의 ID가 필요합니다.");
-    }
-    const result = await userListDao(nickname, roomId);
+    if (!roomId) throw new Error("조회할 공지방의 ID가 필요합니다.");
+  
+    const {adminData, userData} = await userListDao(nickname, roomId, userId);
 
-    if (!result.length) return [];
-    return result.map((user) => ({
-      userId: user.user_id,
-      nickname: user.nickname,
-      profileImage: user.profile_image,
-    }));
+    return userListDTO(adminData, userData) || [];
   } catch (error) {
     console.error("유저 목록 조회 에러:", error);
     throw error;

--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -155,7 +155,7 @@ export const userListService = async (nickname, roomId, userId) => {
   try {
     if (!roomId) throw new Error("조회할 공지방의 ID가 필요합니다.");
   
-    const {adminData = null, userData} = await userListDao(nickname, roomId, userId);
+    const {adminData, userData} = await userListDao(nickname, roomId, userId);
 
     return userListDTO(adminData, userData, nickname) || [];
   } catch (error) {

--- a/domains/admin/admin.service.js
+++ b/domains/admin/admin.service.js
@@ -155,9 +155,9 @@ export const userListService = async (nickname, roomId, userId) => {
   try {
     if (!roomId) throw new Error("조회할 공지방의 ID가 필요합니다.");
   
-    const {adminData, userData} = await userListDao(nickname, roomId, userId);
+    const {adminData = null, userData} = await userListDao(nickname, roomId, userId);
 
-    return userListDTO(adminData, userData) || [];
+    return userListDTO(adminData, userData, nickname) || [];
   } catch (error) {
     console.error("유저 목록 조회 에러:", error);
     throw error;

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -92,6 +92,9 @@ WHERE ur.user_id NOT IN
 `;
 
 // 유저 검색
+export const getAdminInfoSQL =  `
+  SELECT nickname, profile_image FROM \`user-room\` WHERE room_id =? AND user_id = ?;
+`;
 export const userListNameSQL = ` 
   SELECT user_id, nickname, profile_image FROM \`user-room\` WHERE nickname LIKE ? AND room_id = ?; 
 `;

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -100,20 +100,12 @@ export const userListSQL = `
 `;
 
 // 유저 프로필 조회
-export const adminProfileSQL = `
-  SELECT ur.nickname, ur.profile_image
-  FROM \`user-room\` ur
-  JOIN user u ON u.id = ur.user_id
-  JOIN room r ON r.id = ur.room_id  
-  WHERE ur.room_id = ? AND ur.user_id = ?
-`;
-
 export const userProfileSQL = `
-  SELECT ur.user_id, ur.nickname, ur.profile_image
+  SELECT ur.nickname, ur.profile_image, ur.penalty_count, r.max_penalty
   FROM \`user-room\` ur
   JOIN user u ON u.id = ur.user_id
   JOIN room r ON r.id = ur.room_id  
-  WHERE ur.room_id = ?
+  WHERE u.id = ? AND ur.room_id = ?
 `;
 
 // 유저 초대하기 (=공지방 조회)

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -96,10 +96,12 @@ export const getAdminInfoSQL =  `
   SELECT nickname, profile_image FROM \`user-room\` WHERE room_id =? AND user_id = ?;
 `;
 export const userListNameSQL = ` 
-  SELECT user_id, nickname, profile_image FROM \`user-room\` WHERE nickname LIKE ? AND room_id = ?; 
+  SELECT user_id, nickname, profile_image FROM \`user-room\` WHERE nickname LIKE ? AND room_id = ?
+  AND user_id != ?; 
 `;
 export const userListSQL = ` 
-  SELECT user_id, nickname, profile_image FROM \`user-room\` WHERE room_id = ?;
+  SELECT user_id, nickname, profile_image FROM \`user-room\` WHERE room_id = ?
+  AND user_id != ?;
 `;
 
 // 유저 프로필 조회

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -100,12 +100,20 @@ export const userListSQL = `
 `;
 
 // 유저 프로필 조회
-export const userProfileSQL = `
-  SELECT ur.nickname, ur.profile_image, ur.penalty_count, r.max_penalty
+export const adminProfileSQL = `
+  SELECT ur.nickname, ur.profile_image
   FROM \`user-room\` ur
   JOIN user u ON u.id = ur.user_id
   JOIN room r ON r.id = ur.room_id  
-  WHERE u.id = ? AND ur.room_id = ?
+  WHERE ur.room_id = ? AND ur.user_id = ?
+`;
+
+export const userProfileSQL = `
+  SELECT ur.user_id, ur.nickname, ur.profile_image
+  FROM \`user-room\` ur
+  JOIN user u ON u.id = ur.user_id
+  JOIN room r ON r.id = ur.room_id  
+  WHERE ur.room_id = ?
 `;
 
 // 유저 초대하기 (=공지방 조회)

--- a/domains/admin/admin.sql.js
+++ b/domains/admin/admin.sql.js
@@ -96,12 +96,16 @@ export const getAdminInfoSQL =  `
   SELECT nickname, profile_image FROM \`user-room\` WHERE room_id =? AND user_id = ?;
 `;
 export const userListNameSQL = ` 
-  SELECT user_id, nickname, profile_image FROM \`user-room\` WHERE nickname LIKE ? AND room_id = ?
-  AND user_id != ?; 
+  SELECT ur.user_id, ur.nickname, ur.profile_image 
+  FROM \`user-room\` ur
+  JOIN room r ON ur.room_id = r.id
+  WHERE nickname LIKE ? AND ur.room_id = ? AND ur.user_id != r.admin_id; 
 `;
 export const userListSQL = ` 
-  SELECT user_id, nickname, profile_image FROM \`user-room\` WHERE room_id = ?
-  AND user_id != ?;
+  SELECT ur.user_id, ur.nickname, ur.profile_image 
+  FROM \`user-room\` ur 
+  JOIN room r ON ur.room_id = r.id 
+  WHERE ur.room_id = ? AND ur.user_id != r.admin_id;
 `;
 
 // 유저 프로필 조회

--- a/routes/admin.route.js
+++ b/routes/admin.route.js
@@ -32,7 +32,7 @@ adminRouter.patch("/post/:postId", tokenAuth, expressAsyncHandler(updatePostCont
 adminRouter.delete("/post/:postId", tokenAuth, expressAsyncHandler(deletePostController));
 adminRouter.get("/post/:postId/unread", tokenAuth, expressAsyncHandler(unreadUserListController));
 adminRouter.get("/users", tokenAuth, expressAsyncHandler(userListController));
-adminRouter.get("/profile/:roomId", tokenAuth, expressAsyncHandler(userProfileController));
+adminRouter.get("/profile", tokenAuth, expressAsyncHandler(userProfileController));
 adminRouter.get("/invitation/:roomId", tokenAuth, expressAsyncHandler(userInviteController));
 adminRouter.delete("/user-ban", tokenAuth, expressAsyncHandler(deleteUserController));
 

--- a/routes/admin.route.js
+++ b/routes/admin.route.js
@@ -32,7 +32,7 @@ adminRouter.patch("/post/:postId", tokenAuth, expressAsyncHandler(updatePostCont
 adminRouter.delete("/post/:postId", tokenAuth, expressAsyncHandler(deletePostController));
 adminRouter.get("/post/:postId/unread", tokenAuth, expressAsyncHandler(unreadUserListController));
 adminRouter.get("/users", tokenAuth, expressAsyncHandler(userListController));
-adminRouter.get("/profile", tokenAuth, expressAsyncHandler(userProfileController));
+adminRouter.get("/profile/:roomId", tokenAuth, expressAsyncHandler(userProfileController));
 adminRouter.get("/invitation/:roomId", tokenAuth, expressAsyncHandler(userInviteController));
 adminRouter.delete("/user-ban", tokenAuth, expressAsyncHandler(deleteUserController));
 

--- a/swagger/admin.swagger.yaml
+++ b/swagger/admin.swagger.yaml
@@ -542,9 +542,9 @@ paths:
                   result:
                     type: object
                     properties:
-                      deletedPostId:
-                        type: integer
-                        description: 삭제된 공지글 Id
+                      isDeleted:
+                        type: boolean
+                        description: 공지글 삭제 여부
   /admin/post/{postId}/unread:
     get:
       tags:
@@ -613,7 +613,7 @@ paths:
           description: 사용자가 속한 room의 ID
           schema:
             type: integer
-            example: 1
+            example: 85
       responses:
         "200":
           description: 유저 검색 성공!
@@ -634,15 +634,24 @@ paths:
                   result:
                     type: object
                     properties:
-                      userId:
-                        type: integer
-                        description: 유저 아이디
-                      nickname:
-                        type: string
-                        description: 유저 닉네임
-                      profileImage:
-                        type: string
-                        description: 유저 프로필 사진
+                      adminProfile:
+                        type: object
+                        properties: 
+                          nickname:
+                            type: string
+                          profileImage:
+                            type: string
+                      userProfile:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            userId:
+                              type: integer
+                            nickname:
+                              type: string
+                            profileImage:
+                              type: string
 
   /admin/profile:
     get:
@@ -699,9 +708,6 @@ paths:
                       penalty_count:
                         type: integer
                         description: 패널티 개수
-                      max_penalty: 
-                        type: integer
-                        description: 최대 패널티 개수 
 
   /admin/invitation/{roomId}:
     get:


### PR DESCRIPTION
# 🚩 관련 이슈

> [refactor] 유저 검색 api 수정 #252 

닫을 이슈 번호: resolved #252 

## 📌 반영 브랜치

> refactor/#252 -> dev

## 📋 내용

- adminProfile 리턴값에 포함. 
- 응답 바디 형식 수정 

### 🖼️ 스크린샷 
1. 특정 user 닉네임으로 조회 
![image](https://github.com/user-attachments/assets/43265a6c-398f-488d-944e-b588ea40b1a8)

2. 해당 공지방 내 유저 전체 조회 
![image](https://github.com/user-attachments/assets/293ca361-9638-40d0-93c2-a511dcffba5e)



## 요구사항 to 리뷰어

> 리뷰어가 특별히 확인해주었으면 하는 부분을 작성해주세요

